### PR TITLE
performCfgInsertions now takes a type param instead of proxy. Writing…

### DIFF
--- a/examples/lua/Main.hs
+++ b/examples/lua/Main.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
 
 -- |
@@ -109,7 +110,7 @@ main = do
   --putStrLn "\nBasic blocks: "
   --print $ map (^. cfg_node_lab) $ filter (startsBasicBlock cfg) $ cfgNodes cfg
 
-  let t' = evalState (performCfgInsertions (Proxy :: Proxy BlockItemL) progInfo (allbuR $ promoteR doubleAssign) treeLab) gen
+  let t' = evalState (performCfgInsertions @BlockItemL progInfo (allbuR $ promoteR doubleAssign) treeLab) gen
 
   putStrLn $ prettyLua $ stripA t'
 

--- a/src/Cubix/Language/Parametric/Semantics/CfgInserter.hs
+++ b/src/Cubix/Language/Parametric/Semantics/CfgInserter.hs
@@ -231,13 +231,14 @@ finalizeInsertions insertMap t = foldr (\(InsertionOp p x) r -> r >>= insertAt p
 
 
 performCfgInsertions ::
+  forall l fs m i.
   ( MonadAnnotater Label m
   , InsertAt fs l
   , All HTraversable fs
   , All HFunctor fs
   , All HFoldable fs
-  ) => Proxy l -> ProgInfo fs -> RewriteM (CfgInserterT fs l m) (TermLab fs) i -> RewriteM m (TermLab fs) i
-performCfgInsertions _ proginf f t = do
+  ) => ProgInfo fs -> RewriteM (CfgInserterT fs l m) (TermLab fs) i -> RewriteM m (TermLab fs) i
+performCfgInsertions proginf f t = do
    (t', actions) <- runWriterT (f t)
    s <- execStateT (mapM_ runAction actions) (CfgInsertState Map.empty proginf)
    allbuR (finalizeInsertions (s ^. pendingInsertions)) t'

--- a/src/Cubix/Transformations/TAC/ToTAC.hs
+++ b/src/Cubix/Transformations/TAC/ToTAC.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE RankNTypes             #-}
 {-# LANGUAGE ScopedTypeVariables    #-}
 {-# LANGUAGE TemplateHaskell        #-}
+{-# LANGUAGE TypeApplications       #-}
 {-# LANGUAGE TypeOperators          #-}
 {-# LANGUAGE TypeSynonymInstances   #-}
 {-# LANGUAGE TypeFamilies           #-}
@@ -354,7 +355,7 @@ toTAC t = do
    let progInf = makeProgInfo t
    randGen <- getStdGen
 
-   let inserted = performCfgInsertions (Proxy :: Proxy BlockItemL) progInf trans t
+   let inserted = performCfgInsertions @BlockItemL progInf trans t
    let evalled  = evalState (evalRandT inserted randGen) (makeTACState gen (GensymState 0 allIds Map.empty))
    return $ evalState (finalizeGensymNames evalled) (GensymState 0 allIds Map.empty)
   where


### PR DESCRIPTION
… (in comments) a simplified instrumentTestCoverage for use in examples.