### PR TITLE
Move to kind synonyms

### DIFF
--- a/compdata/cubix-compdata.cabal
+++ b/compdata/cubix-compdata.cabal
@@ -28,6 +28,7 @@ library
                         Data.Comp.Ops
 
                         Data.Comp.Multi
+                        Data.Comp.Multi.Kinds
                         Data.Comp.Multi.Term
                         Data.Comp.Multi.Sum
                         Data.Comp.Multi.HFunctor

--- a/compdata/src/Data/Comp/Multi.hs
+++ b/compdata/src/Data/Comp/Multi.hs
@@ -24,6 +24,7 @@ module Data.Comp.Multi (
   , module Data.Comp.Multi.HFoldable
   , module Data.Comp.Multi.HFunctor
   , module Data.Comp.Multi.HTraversable
+  , module Data.Comp.Multi.Kinds
   , module Data.Comp.Multi.Ops
   , module Data.Comp.Multi.Ordering
   , module Data.Comp.Multi.Show
@@ -39,6 +40,7 @@ import Data.Comp.Multi.Generic
 import Data.Comp.Multi.HFoldable
 import Data.Comp.Multi.HFunctor
 import Data.Comp.Multi.HTraversable
+import Data.Comp.Multi.Kinds
 import Data.Comp.Multi.Ops
 import Data.Comp.Multi.Ordering
 import Data.Comp.Multi.Show

--- a/compdata/src/Data/Comp/Multi/Algebra.hs
+++ b/compdata/src/Data/Comp/Multi/Algebra.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE KindSignatures      #-}
@@ -93,6 +94,7 @@ module Data.Comp.Multi.Algebra (
 import Control.Monad
 import Data.Comp.Multi.HFunctor
 import Data.Comp.Multi.HTraversable
+import Data.Comp.Multi.Kinds
 import Data.Comp.Multi.Term
 import Data.Comp.Ops
 
@@ -164,7 +166,7 @@ cataM' f = run
 
 
 -- | This type represents uniform signature function specification.
-type SigFun f g = forall (a :: * -> *). f a :-> g a
+type SigFun f g = forall a. (f :: Fragment) a :-> g a
 
 -- | This type represents context function.
 type CxtFun f g = forall h . SigFun (Cxt h f) (Cxt h g)

--- a/compdata/src/Data/Comp/Multi/Alt.hs
+++ b/compdata/src/Data/Comp/Multi/Alt.hs
@@ -19,10 +19,13 @@ import qualified Unsafe.Coerce as U
 import GHC.Types
 
 import Data.Comp.Elem
+import Data.Comp.Multi.Kinds
+
+---------------------------------------------------------------
 
 newtype Alt f (a :: * -> *) e b = Alt (f a e -> b)
 
-newtype Alts (fs :: [(* -> *) -> * -> *]) (a :: * -> *) e b =
+newtype Alts (fs :: Signature) (a :: * -> *) e b =
   Alts (Vector (Alt Any a e b))
 
 alt :: (f a e -> b) -> Alt f a e b

--- a/compdata/src/Data/Comp/Multi/Annotation.hs
+++ b/compdata/src/Data/Comp/Multi/Annotation.hs
@@ -54,6 +54,7 @@ import Data.Comp.Dict
 import Data.Comp.Elem
 import Data.Comp.Multi.Algebra
 import Data.Comp.Multi.HFunctor
+import Data.Comp.Multi.Kinds
 import Data.Comp.Multi.Ops
 import Data.Comp.Multi.Sum
 import Data.Comp.Multi.Term
@@ -129,7 +130,7 @@ caseCxt'' _ f (Sum wit v :&: a) =
         annWit = unsafeElem
 
 
-type family DistAnn (fs :: [(* -> *) -> * -> *]) (a :: *) :: [(* -> *) -> * -> *] where
+type family DistAnn (fs :: Signature) (a :: *) :: Signature where
   DistAnn (f ': fs) a = f :&: a ': DistAnn fs a
   DistAnn '[]       _ = '[]
 

--- a/compdata/src/Data/Comp/Multi/HFunctor.hs
+++ b/compdata/src/Data/Comp/Multi/HFunctor.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveTraversable         #-}
 {-# LANGUAGE DeriveFoldable            #-}
 {-# LANGUAGE DeriveFunctor             #-}
@@ -14,7 +15,7 @@
 --------------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Comp.Multi.HFunctor
--- Copyright   :  (c) 2011 Patrick Bahr
+-- Copyright   :  Original (c) 2011 Patrick Bahr; modifications (c) 2020 James Koppel
 -- License     :  BSD3
 -- Maintainer  :  Patrick Bahr <paba@diku.dk>
 -- Stability   :  experimental
@@ -43,6 +44,7 @@ module Data.Comp.Multi.HFunctor
      ) where
 
 import Data.Functor.Compose
+import Data.Comp.Multi.Kinds
 
 -- | The identity Functor.
 newtype I a = I {unI :: a} deriving (Functor, Foldable, Traversable)
@@ -111,6 +113,6 @@ instance (Functor f) => HFunctor (Compose f) where hfmap f (Compose xs) = Compos
 infixl 5 :.:
 
 -- | This data type denotes the composition of two functor families.
-data (:.:) f (g :: (* -> *) -> (* -> *)) (e :: * -> *) t = Comp (f (g e) t)
+data (:.:) (f :: Node) (g :: Node) e t = Comp (f (g e) t)
 
 newtype HMonad m f i = HMonad { unHMonad :: m (f i) }

--- a/compdata/src/Data/Comp/Multi/Kinds.hs
+++ b/compdata/src/Data/Comp/Multi/Kinds.hs
@@ -1,0 +1,22 @@
+-- |
+-- Module      :  Data.Comp.Kinds
+-- Copyright   : (c) 2020 James Koppel
+-- License     :  BSD3
+--
+-- This module provides kind-synonyms for the common kinds in this package.
+-- All such kinds should be treated opaquely.
+--
+--------------------------------------------------------------------------------
+
+module Data.Comp.Multi.Kinds
+    ( Sort
+    , Node
+    , Fragment
+    , Signature
+    ) where
+
+type Sort      = *
+type Family    = Sort -> *
+type Node      = Family -> Family
+type Fragment  = Family -> Family
+type Signature = [Fragment]

--- a/compdata/src/Data/Comp/Multi/Kinds.hs
+++ b/compdata/src/Data/Comp/Multi/Kinds.hs
@@ -10,6 +10,7 @@
 
 module Data.Comp.Multi.Kinds
     ( Sort
+    , Family
     , Node
     , Fragment
     , Signature

--- a/compdata/src/Data/Comp/Multi/Ops.hs
+++ b/compdata/src/Data/Comp/Multi/Ops.hs
@@ -68,14 +68,16 @@ import Control.Monad
 import Data.Type.Equality
 import Data.Proxy
 import Data.Functor.Identity
+import Data.Comp.Multi.Alt
 import Data.Comp.Multi.HFoldable
 import Data.Comp.Multi.HFunctor
 import Data.Comp.Multi.HTraversable
-import Data.Comp.Multi.Alt
+import Data.Comp.Multi.Kinds
 import qualified Data.Comp.Ops as O
 import Data.Comp.Elem
 import Data.Comp.Dict
 
+-------------------------------------------------------------
 
 -- | Data type defining a sum of signatures.
 --
@@ -91,7 +93,7 @@ import Data.Comp.Dict
 --   of summands (unlike vanilla datatypes à la carte), and constant time to dereference
 --   (unlike modular reifiable matching). The representation is the bare minimum: an int representing the alternative,
 --   and pointer to the value.
-data Sum (fs :: [(* -> *) -> * -> *]) h e where
+data Sum (fs :: Signature) h e where
   Sum :: Elem f fs -> f h e -> Sum fs h e
 
 at :: Elem f fs -> Sum fs a e -> Maybe (f a e)
@@ -142,7 +144,7 @@ instance ( All HTraversable fs
 infixl 5 :<:
 infixl 5 :=:
 
-class (f :: (* -> *) -> * -> *) :<: (g :: (* -> *) -> * -> *) where
+class (f :: Fragment) :<: (g :: Fragment) where
   inj :: f a :-> g a
   proj :: NatM Maybe (g a) (f a)
 
@@ -169,12 +171,12 @@ infixr 7 :&:
 -- signature. Alternatively, this could have also been defined as
 --
 -- @
--- data (f :&: a) (g ::  * -> *) e = f g e :&: a e
+-- data ((f :: Node) :&: a) g e = f g e :&: a e
 -- @
 --
 -- This is too general, however, for example for 'productHHom'.
 
-data (f :&: a) (g ::  * -> *) e = f g e :&: a
+data ((f :: Node) :&: a) g e = f g e :&: a
 
 instance (HFunctor f) => HFunctor (f :&: a) where
     hfmap f (v :&: c) = hfmap f v :&: c
@@ -192,7 +194,7 @@ instance (HTraversable f) => HTraversable (f :&: a) where
     htraverse f (v :&: c) =  (:&: c) <$> (htraverse f v)
     hmapM f (v :&: c) = liftM (:&: c) (hmapM f v)
 
-class RemA (s :: (* -> *) -> * -> *) s' | s -> s'  where
+class RemA (s :: Node) s' | s -> s'  where
     remA :: s a :-> s' a
 
 -- TODO: This is linear

--- a/compdata/src/Data/Comp/Multi/Sum.hs
+++ b/compdata/src/Data/Comp/Multi/Sum.hs
@@ -60,6 +60,7 @@ import Data.Proxy ( Proxy )
 import Data.Comp.Multi.Algebra
 import Data.Comp.Multi.HFunctor
 import Data.Comp.Multi.HTraversable
+import Data.Comp.Multi.Kinds
 import Data.Comp.Multi.Ops
 import Data.Comp.Multi.Term
 
@@ -120,7 +121,7 @@ projectConst = fmap (hfmap (const (K ()))) . project
 
 -- Used to prevent typechecker from applying the default cases when it shouldn't,
 -- i.e.: it can't use the default case when it only has a type variable for the signature
-type family IsSum (f :: (* -> *) -> * -> *) :: Bool where
+type family IsSum (f :: Node) :: Bool where
   IsSum (Sum fs) = True
   IsSum f        = False
 

--- a/compdata/src/Data/Comp/Multi/Variables.hs
+++ b/compdata/src/Data/Comp/Multi/Variables.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE GADTs                 #-}
@@ -49,6 +50,7 @@ import Data.Comp.Multi.Algebra
 import Data.Comp.Multi.Derive
 import Data.Comp.Multi.HFoldable
 import Data.Comp.Multi.HFunctor
+import Data.Comp.Multi.Kinds
 import Data.Comp.Multi.Mapping
 import Data.Comp.Multi.Ops
 
@@ -75,7 +77,7 @@ substFun s (K v) = fmap unA $ Map.lookup v s
 {-| This multiparameter class defines functors with variables. An instance
   @HasVar f v@ denotes that values over @f@ might contain and bind variables of
   type @v@. -}
-class HasVars v (f  :: (* -> *) -> * -> *) where
+class HasVars v (f  :: Node) where
     -- | Indicates whether the @f@ constructor is a variable. The
     -- default implementation returns @Nothing@.
     isVar :: f a :=> Maybe v

--- a/compdata/stack.yaml
+++ b/compdata/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-6.12
+resolver: lts-16.3
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/compstrat/Data/Comp/Multi/Strategy/Classification.hs
+++ b/compstrat/Data/Comp/Multi/Strategy/Classification.hs
@@ -43,12 +43,12 @@ import Data.Proxy
 
 import GHC.Exts ( Constraint )
 
-import Data.Comp.Multi ( HFix, Sum, E, K, runE, caseH, (:&:), remA, Cxt(..), subs, NotSum, All, caseCxt )
+import Data.Comp.Multi ( Family, Node, HFix, Sum, E, K, runE, caseH, (:&:), remA, Cxt(..), subs, NotSum, All, caseCxt )
 import Data.Comp.Multi.HFoldable ( HFoldable )
 
 --------------------------------------------------------------------------------
 
-class EmptyConstraint (e :: * -> *) l
+class EmptyConstraint (e :: Family) l
 instance EmptyConstraint e l
 
 -- |
@@ -60,7 +60,7 @@ class DynCase f a where
   dyncase :: f b -> Maybe (b :~: a)
 
 -- | An instance @KDynCase f a@ defines an instance @DynCase (HFix f) a@
-class KDynCase (f :: (* -> *) -> * -> *) a where
+class KDynCase (f :: Node) a where
   kdyncase :: f e b -> Maybe (b :~: a)
 
 -- Stop typeclass resolver from using this when it shouldn't

--- a/comptrans/examples/generics/GenericExample.hs
+++ b/comptrans/examples/generics/GenericExample.hs
@@ -24,7 +24,7 @@ data Atom e l where
    Var :: String -> Atom e AtomL
    Const :: e LitL -> Atom e AtomL
 
-data Lit (e :: * -> *) l where
+data Lit (e :: M.Family) l where
    Lit :: Int -> Lit e LitL
 
 data MaybeF e l where

--- a/src/Cubix/Language/C/Parametric/Common/Types.hs
+++ b/src/Cubix/Language/C/Parametric/Common/Types.hs
@@ -25,7 +25,7 @@ import Data.List ( (\\) )
 
 import Language.Haskell.TH ( mkName )
 
-import Data.Comp.Multi ( HFunctor, Term, project', project, (:-<:), CxtS, All, AnnCxtS )
+import Data.Comp.Multi ( Node, HFunctor, Term, project', project, (:-<:), CxtS, All, AnnCxtS )
 import Data.Comp.Trans ( runCompTrans, makeSumType )
 
 import Cubix.Language.C.Parametric.Full.Names
@@ -157,7 +157,7 @@ data CDeclaration a
 -- In function decls, since we don't model that void isn't a type,
 -- this becomes just a special case of a normal param, and we don't include it
 data CSpecialParamL
-data CVoidArg (e :: * -> *) l where
+data CVoidArg :: Node where
   CVoidArg :: CVoidArg e CSpecialParamL
 
 -- NOTE: I don't derive these all on one line because GHC crashes
@@ -168,7 +168,7 @@ pattern CVoidArg' :: (CVoidArg :-<: fs, All HFunctor fs) => CxtS h fs a CSpecial
 pattern CVoidArg' <- (project -> Just CVoidArg) where
   CVoidArg' = iCVoidArg
 
-data CVarArgParam (e :: * -> *) l where
+data CVarArgParam :: Node where
   CVarArgParam :: CVarArgParam e CSpecialParamL
 
 deriveAll [''CVarArgParam]

--- a/src/Cubix/Language/Java/Parametric/Common/Types.hs
+++ b/src/Cubix/Language/Java/Parametric/Common/Types.hs
@@ -25,7 +25,7 @@ import Data.List ( (\\) )
 
 import Language.Haskell.TH.Syntax ( mkName )
 
-import Data.Comp.Multi ( Term, project', project, HFunctor, (:-<:), All, CxtS, AnnCxtS )
+import Data.Comp.Multi ( Node, Term, project', project, HFunctor, (:-<:), All, CxtS, AnnCxtS )
 import Data.Comp.Trans ( makeSumType, runCompTrans )
 
 import Cubix.Language.Info
@@ -42,7 +42,7 @@ import Cubix.Language.Parametric.Syntax as P
 ---------------       Variable declarations and blocks     ------------------------
 -----------------------------------------------------------------------------------
 
-data ArrayDimVarDeclAttrs (e :: * -> *) l where
+data ArrayDimVarDeclAttrs :: Node where
   ArrayDimVarDeclAttrs :: Int -> ArrayDimVarDeclAttrs e LocalVarDeclAttrsL
 
 

--- a/src/Cubix/Language/Lua/Parametric/Common/Types.hs
+++ b/src/Cubix/Language/Lua/Parametric/Common/Types.hs
@@ -24,7 +24,7 @@ import Data.List ( (\\) )
 
 import Language.Haskell.TH.Syntax ( mkName )
 
-import Data.Comp.Multi ( Term, project', AnnTerm, (:-<:), All, HFunctor, project, CxtS, AnnCxtS )
+import Data.Comp.Multi ( Node, Term, project', AnnTerm, (:-<:), All, HFunctor, project, CxtS, AnnCxtS )
 import Data.Comp.Trans ( makeSumType, runCompTrans )
 
 import Cubix.Language.Info
@@ -85,7 +85,7 @@ data LuaFunctionAttrs e l where
 
 deriveAll [''LuaFunctionAttrs]
 
-data LuaVarArgsParam (e :: * -> *) l where
+data LuaVarArgsParam :: Node where
   LuaVarArgsParam :: LuaVarArgsParam e FunctionParameterL
 
 deriveAll [''LuaVarArgsParam]

--- a/src/Cubix/Language/Parametric/InjF.hs
+++ b/src/Cubix/Language/Parametric/InjF.hs
@@ -32,7 +32,7 @@ import Control.Monad ( MonadPlus(..), liftM )
 import Data.Proxy ( Proxy(..) )
 import Data.Type.Equality ( (:~:), gcastWith )
 
-import Data.Comp.Multi ( Cxt(..), (:-<:),  (:&:), Cxt, inject, ann, stripA, HFunctor(..), HTraversable, AnnTerm, Sum, All, CxtS, HFoldable )
+import Data.Comp.Multi ( Signature, Sort, Cxt(..), (:-<:),  (:&:), Cxt, inject, ann, stripA, HFunctor(..), HTraversable, AnnTerm, Sum, All, CxtS, HFoldable )
 import Data.Comp.Multi.Strategic ( RewriteM, GRewriteM )
 import Data.Comp.Multi.Strategy.Classification ( DynCase(..), KDynCase(..) )
 
@@ -105,13 +105,13 @@ injectFAnnDef =  injFAnnDef . inject
 --------------------------------------------------------------------------------
 
 
-type family InjectableSorts (sig :: [(* -> *) -> * -> *]) (sort :: *) :: [*]
+type family InjectableSorts (fs :: Signature) (l :: Sort) :: [Sort]
 
 -- NOTE: There should be some way to express this in terms of the Lens library
 class AInjF fs l where
   ainjF :: (MonadAnnotater Label m) => TermLab fs l' -> Maybe (TermLab fs l, TermLab fs l -> m (TermLab fs l'))
 
-class AInjF' fs l (is :: [*]) where
+class AInjF' fs l (is :: [Sort]) where
   ainjF' :: (MonadAnnotater Label m) => Proxy is -> TermLab fs l' -> Maybe (TermLab fs l, TermLab fs l -> m (TermLab fs l'))
 
 instance AInjF' fs l '[] where

--- a/src/Cubix/Language/Parametric/Semantics/Cfg/CfgConstruction.hs
+++ b/src/Cubix/Language/Parametric/Semantics/Cfg/CfgConstruction.hs
@@ -54,7 +54,7 @@ import Data.Typeable ( Typeable )
 
 import Control.Lens ( (^.), (%=)  )
 
-import Data.Comp.Multi ( Cxt(..), (:->), K(..), inj, proj, project, para, stripA, inj, Sum, HFunctor(..), HFoldable(..), HTraversable(..), (:*:)(..), (:&:)(..), ffst, fsnd, ShowHF(..), inj', caseCxt', All, HFix, AnnTerm, Term, (:-<:) )
+import Data.Comp.Multi ( Node, Signature, Cxt(..), (:->), K(..), inj, proj, project, para, stripA, inj, Sum, HFunctor(..), HFoldable(..), HTraversable(..), (:*:)(..), (:&:)(..), ffst, fsnd, ShowHF(..), inj', caseCxt', All, HFix, AnnTerm, Term, (:-<:) )
 import Data.Comp.Multi.Strategy.Classification ( DynCase, isSort )
 
 import Cubix.Language.Info
@@ -63,7 +63,7 @@ import Cubix.Language.Parametric.Syntax.Functor
 
 --------------------------------------------------------------------------------------
 
-type family ComputationSorts (fs :: [(* -> *) -> * -> *]) :: [*]
+type family ComputationSorts (fs :: Signature) :: [*]
 
 class IsComputationSort' fs (l :: [*]) where
   isComputationSort' :: Proxy l -> Term fs i -> Bool
@@ -83,7 +83,7 @@ instance (IsComputationSort' fs ls, DynCase (Term fs) l) => IsComputationSort' f
 labeledIsComputationSort :: forall fs l. (IsComputationSort fs, All HFunctor fs) => TermLab fs l -> Bool
 labeledIsComputationSort = isComputationSort . stripA
 
-type family SuspendedComputationSorts (fs :: [(* -> *) -> * -> *]) :: [*]
+type family SuspendedComputationSorts (fs :: Signature) :: [*]
 
 class IsSuspendedComputationSort' fs (l :: [*]) where
   isSuspendedComputationSort' :: Proxy l -> Term fs i -> Bool
@@ -103,9 +103,9 @@ instance (IsSuspendedComputationSort' fs ls, DynCase (Term fs) l) => IsSuspended
 labeledIsSuspendedComputationSort :: (IsSuspendedComputationSort fs, All HFunctor fs) => AnnTerm a fs l -> Bool
 labeledIsSuspendedComputationSort = isSuspendedComputationSort . stripA
 
-type family ContainerFunctors (fs :: [(* -> *) -> * -> *]) :: [(* -> *) -> * -> *]
+type family ContainerFunctors (fs :: Signature) :: [Node]
 
-class IsContainer' fs (l :: [(* -> *) -> * -> *])where
+class IsContainer' fs (l :: Signature)where
   isContainer' :: Proxy l -> Term fs i -> Bool
 
 class IsContainer fs where
@@ -304,7 +304,7 @@ instance {-# OVERLAPPING #-} (All (ConstructCfg g s) fs) => ConstructCfg g s (Su
 
 ------------------------------------------------------------------------------------------------------------------------
 
-type family CfgState (f :: [(* -> *) -> * -> *]) :: *
+type family CfgState (fs :: Signature) :: *
 
 class CfgInitState fs where
    cfgInitState :: Proxy fs -> CfgState fs

--- a/src/Cubix/Language/Parametric/Syntax/Base.hs
+++ b/src/Cubix/Language/Parametric/Syntax/Base.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
@@ -38,27 +39,27 @@ module Cubix.Language.Parametric.Syntax.Base (
   ,        iUnitF
   ) where
 
-import Data.Comp.Multi ( CxtS, All, HFunctor, (:-<:), project)
+import Data.Comp.Multi ( Node, CxtS, All, HFunctor, (:-<:), project)
 
 import Cubix.Language.Parametric.Derive
 
 data BoolL
-data BoolF (e :: * -> *) l where
+data BoolF :: Node where
   BoolF :: Bool -> BoolF e BoolL
 
 data IntL
-data IntF (e :: * -> *) l where
+data IntF :: Node where
   IntF :: Int -> IntF e IntL
 
 data IntegerL
-data IntegerF (e :: * -> *) l where
+data IntegerF :: Node where
   IntegerF :: Integer -> IntegerF e IntegerL
 
 data CharL
-data CharF (e :: * -> *) l where
+data CharF :: Node where
   CharF :: Char -> CharF e CharL
 
-data UnitF (e :: * -> *) l where
+data UnitF :: Node where
   UnitF :: UnitF e ()
 
 

--- a/src/Cubix/Language/Parametric/Syntax/Function.hs
+++ b/src/Cubix/Language/Parametric/Syntax/Function.hs
@@ -1,4 +1,4 @@
-
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -92,7 +92,7 @@ module Cubix.Language.Parametric.Syntax.Function (
 
   ) where
 
-import Data.Comp.Multi (CxtS,project, (:-<:), HFunctor, All )
+import Data.Comp.Multi (Node, CxtS,project, (:-<:), HFunctor, All )
 
 import Cubix.Language.Parametric.Derive
 import Cubix.Language.Parametric.Syntax.VarDecl
@@ -133,7 +133,7 @@ pattern FunctionCall' ::
 pattern FunctionCall' a e args <- (project -> Just (FunctionCall a e args)) where
   FunctionCall' a e args = iFunctionCall a e args
 
-data EmptyFunctionCallAttrs (e :: * -> *) l where
+data EmptyFunctionCallAttrs :: Node where
   EmptyFunctionCallAttrs :: EmptyFunctionCallAttrs e FunctionCallAttrsL
 
 deriveAll [''EmptyFunctionCallAttrs]
@@ -156,7 +156,7 @@ pattern FunctionIdent' n <- (project -> Just (FunctionIdent n)) where
 --     it's at the front of the list if exists.
 -- * Positional and receiver args are before other args
 data FunctionArgumentL
-data FunctionArgumentList e l where
+data FunctionArgumentList :: Node where
   FunctionArgumentList :: e [FunctionArgumentL] -> FunctionArgumentList e FunctionArgumentsL
 
 deriveAll [''FunctionArgumentList]
@@ -176,7 +176,7 @@ pattern ReceiverArg' x <- (project -> Just (ReceiverArg x)) where
   ReceiverArg' x = iReceiverArg x
 
 data PositionalArgExpL
-data PositionalArgument e l where
+data PositionalArgument :: Node where
   PositionalArgument :: e PositionalArgExpL -> PositionalArgument e FunctionArgumentL
 
 deriveAll [''PositionalArgument]
@@ -203,7 +203,7 @@ pattern FunctionDecl' :: (FunctionDecl :-<: fs, All HFunctor fs) => CxtS h fs a 
 pattern FunctionDecl' a n ps <- (project -> (Just (FunctionDecl a n ps))) where
   FunctionDecl' a n ps = iFunctionDecl a n ps
 
-data EmptyFunctionDeclAttrs (e :: * -> *) l where
+data EmptyFunctionDeclAttrs :: Node where
   EmptyFunctionDeclAttrs :: EmptyFunctionDeclAttrs e FunctionDeclAttrsL
 
 deriveAll [''EmptyFunctionDeclAttrs]
@@ -212,7 +212,7 @@ pattern EmptyFunctionDeclAttrs' :: (EmptyFunctionDeclAttrs :-<: fs, All HFunctor
 pattern EmptyFunctionDeclAttrs' <- (project -> Just EmptyFunctionDeclAttrs) where
   EmptyFunctionDeclAttrs' = iEmptyFunctionDeclAttrs
 
-data SelfParameterDecl (e :: * -> *) l where
+data SelfParameterDecl :: Node where
   SelfParameterDecl :: SelfParameterDecl e FunctionParameterDeclL
 
 deriveAll [''SelfParameterDecl]
@@ -276,7 +276,7 @@ pattern FunctionDef' ::
 pattern FunctionDef' attrs i args body <- (project -> Just (FunctionDef attrs i args body)) where
   FunctionDef' attrs i args body = iFunctionDef attrs i args body
 
-data EmptyFunctionDefAttrs (e :: * -> *) l where
+data EmptyFunctionDefAttrs :: Node where
   EmptyFunctionDefAttrs :: EmptyFunctionDefAttrs e FunctionDefAttrsL
 
 deriveAll [''EmptyFunctionDefAttrs]
@@ -285,7 +285,7 @@ pattern EmptyFunctionDefAttrs' :: (EmptyFunctionDefAttrs :-<: fs, All HFunctor f
 pattern EmptyFunctionDefAttrs' <- (project -> Just EmptyFunctionDefAttrs) where
   EmptyFunctionDefAttrs' = iEmptyFunctionDefAttrs
 
-data SelfParameter (e :: * -> *) l where
+data SelfParameter :: Node where
   SelfParameter :: SelfParameter e FunctionParameterL
 
 deriveAll [''SelfParameter]
@@ -305,7 +305,7 @@ pattern PositionalParameter' ::
 pattern PositionalParameter' attrs i <- (project -> Just (PositionalParameter attrs i)) where
   PositionalParameter' attrs i = iPositionalParameter attrs i
 
-data EmptyParameterAttrs (e :: * -> *) l where
+data EmptyParameterAttrs :: Node where
   EmptyParameterAttrs :: EmptyParameterAttrs e ParameterAttrsL
 
 deriveAll [''EmptyParameterAttrs]

--- a/src/Cubix/Language/Parametric/Syntax/VarDecl.hs
+++ b/src/Cubix/Language/Parametric/Syntax/VarDecl.hs
@@ -99,12 +99,12 @@ module Cubix.Language.Parametric.Syntax.VarDecl (
   ,        iEmptyBlockItem
   ) where
 
-import Data.Comp.Multi ( project, project', HFunctor, (:-<:), All, CxtS)
+import Data.Comp.Multi ( Node, project, project', HFunctor, (:-<:), All, CxtS)
 import Cubix.Language.Parametric.Derive
 import Cubix.Language.Parametric.InjF
 
 data IdentL
-data Ident (e :: * -> *) l where
+data Ident :: Node where
   Ident :: String -> Ident e IdentL
 
 deriveAll [''Ident]
@@ -145,7 +145,7 @@ data LocalVarDeclAttrsL
 -- Needs better name because may need to distinguish part of multi-decl from a standalone decl
 ------ That's a really hypothetical thing. Why, Jimmy, why
 
-data EmptyLocalVarDeclAttrs (e :: * -> *) l where
+data EmptyLocalVarDeclAttrs :: Node where
   EmptyLocalVarDeclAttrs :: EmptyLocalVarDeclAttrs e LocalVarDeclAttrsL
 
 deriveAll [''EmptyLocalVarDeclAttrs]
@@ -218,7 +218,7 @@ pattern SingleLocalVarDecl' x y z <- (project -> (Just (SingleLocalVarDecl x y z
   SingleLocalVarDecl' x y z = iSingleLocalVarDecl x y z
 
 
-data EmptyMultiLocalVarDeclCommonAttrs (e :: * -> *) l where
+data EmptyMultiLocalVarDeclCommonAttrs :: Node where
   EmptyMultiLocalVarDeclCommonAttrs :: EmptyMultiLocalVarDeclCommonAttrs e MultiLocalVarDeclCommonAttrsL
 
 deriveAll [''EmptyMultiLocalVarDeclCommonAttrs]
@@ -266,7 +266,7 @@ pattern MultiLocalVarDecl' x y <- (project -> (Just (MultiLocalVarDecl x y))) wh
 -- where (typeof x)y denotes a type conversion from y to the type of x. We leave it unspecified what
 -- exactly that means
 data AssignOpL
-data AssignOpEquals (e :: * -> *) l where
+data AssignOpEquals :: Node where
   AssignOpEquals :: AssignOpEquals e AssignOpL
 
 deriveAll [''AssignOpEquals]
@@ -313,7 +313,7 @@ data BlockItemL
 data BlockEndL
 data BlockL
 
-data EmptyBlockEnd (e :: * -> *) l where
+data EmptyBlockEnd :: Node where
   EmptyBlockEnd :: EmptyBlockEnd e BlockEndL
 
 deriveAll [''EmptyBlockEnd]
@@ -343,7 +343,7 @@ pattern Block' xs e <- (project -> Just (Block xs e)) where
 -- and so that the sort of empty block-item lists can be correctly determined
 --
 -- This is a bit of a hack....but, it's actually kinda nice in some ways
-data EmptyBlockItem (e :: * -> *) l where
+data EmptyBlockItem :: Node where
   EmptyBlockItem :: EmptyBlockItem e BlockItemL
 
 deriveAll [''EmptyBlockItem]

--- a/src/Cubix/Language/Python/Parametric/Common/Types.hs
+++ b/src/Cubix/Language/Python/Parametric/Common/Types.hs
@@ -22,7 +22,7 @@ module Cubix.Language.Python.Parametric.Common.Types where
 import Data.List ( (\\) )
 import Language.Haskell.TH ( mkName )
 
-import Data.Comp.Multi ( Term, project', project, HFunctor, CxtS, All, (:-<:) )
+import Data.Comp.Multi ( Node, Term, project', project, HFunctor, CxtS, All, (:-<:) )
 import Data.Comp.Trans ( runCompTrans, makeSumType )
 
 import Cubix.Language.Info
@@ -86,7 +86,7 @@ data PyWithBinder e l where
 -- Extracting out this sort for docstring support
 
 data PyStringLitL
-data PyStringLit (e :: * -> *) l where
+data PyStringLit :: Node where
   PyStrings :: [String] -> PyStringLit e PyStringLitL
   PyUnicodeStrings :: [String] -> PyStringLit e PyStringLitL
   PyByteStrings :: [String] -> PyStringLit e PyStringLitL

--- a/src/Cubix/Sin/Compdata/Annotation.hs
+++ b/src/Cubix/Sin/Compdata/Annotation.hs
@@ -26,7 +26,7 @@ module Cubix.Sin.Compdata.Annotation (
 import Control.Monad.Identity ( Identity(..) )
 import Control.Monad.Trans ( MonadTrans(..) )
 import Data.Default ( Default(..) )
-import Data.Comp.Multi ( Cxt(..), (:=>), CxtFunM, SigFun, appSigFunM, HFix, AnnHFix )
+import Data.Comp.Multi ( Node, Cxt(..), (:=>), CxtFunM, SigFun, appSigFunM, HFix, AnnHFix )
 import Data.Comp.Multi.HTraversable ( HTraversable )
 import Data.Comp.Multi.Ops ((:&:)(..), Sum (..), contract)
 
@@ -36,7 +36,7 @@ import Data.Type.Equality
 ---- This exists so you can constrain a functor to be annotated without also
 ---- naming the unannotated functor. This makes it more convenient for inclusion
 ---- in constraint synonyms
-class Annotated (f :: (* -> *) -> * -> *) a | f -> a where
+class Annotated (f :: Node) a | f -> a where
   getAnn' :: f e l -> a
 
 instance Annotated (f :&: a) a where
@@ -57,7 +57,7 @@ getAnn :: (Annotated f a) => HFix f :=> a
 getAnn (Term x) = getAnn' x
 
 class (Monad m) => MonadAnnotater a m where
-  annM :: forall f (e :: * -> *) l. f e l -> m ((f :&: a) e l)
+  annM :: forall (f :: Node) e l. f e l -> m ((f :&: a) e l)
 
 newtype AnnotateDefault a x = AnnotateDefault' { runAnnotateDefault' :: Identity x}
   deriving ( Functor, Applicative, Monad )

--- a/src/Cubix/Transformations/Hoist/Custom.hs
+++ b/src/Cubix/Transformations/Hoist/Custom.hs
@@ -34,7 +34,7 @@ import qualified Data.Set as Set
 
 import Control.Lens ( makeLenses, (^.), (%=) )
 
-import Data.Comp.Multi ( project, Term )
+import Data.Comp.Multi ( Signature, project, Term )
 import Data.Comp.Multi.Strategic ( Rewrite, alltdR, promoteR, addFail )
 import Data.Comp.Multi.Strategy.Classification ( subterms )
 
@@ -47,7 +47,7 @@ import Cubix.Language.Parametric.InjF
 
 import Cubix.Transformations.Variation
 
-type family SpecialHoistState (fs :: [(* -> *) -> * -> *]) :: *
+type family SpecialHoistState (fs :: Signature) :: *
 
 data HoistState fs = HoistState {
                                  _seenIdents   :: Set String
@@ -256,7 +256,7 @@ instance {-# OVERLAPPABLE #-} SpecialHoist MCSig where
 --
 -- For instance, in Lua, changing "local _ENV = x" to "local _ENV; _ENV = x" will have the effect
 -- of temporarily setting _ENV to nil, which then renders all variables (including "x") inacessible
-class BuiltinSpecialIdents (fs :: [(* -> *) -> * -> *]) where
+class BuiltinSpecialIdents (fs :: Signature) where
   builtinReferencedIdents :: Proxy fs -> Set String
 
 instance {-# OVERLAPPABLE #-} BuiltinSpecialIdents fs where

--- a/src/Cubix/Transformations/Hoist/Hoisting.hs
+++ b/src/Cubix/Transformations/Hoist/Hoisting.hs
@@ -31,7 +31,7 @@ import Data.Traversable ( for )
 import Control.Lens ( (&), (.~), (%=), (.=), (^.), use, Lens' )
 
 import Data.Constraint ( Dict(..) )
-import Data.Comp.Multi ( HTraversable, HFunctor, Term, (:-<:), All, HFoldable )
+import Data.Comp.Multi ( Signature, HTraversable, HFunctor, Term, (:-<:), All, HFoldable )
 
 import Data.Comp.Multi.Strategic ( Rewrite, RewriteM, GRewrite, GRewriteM,
                                    promoteR, addFail, tryR, allR, alltdR,
@@ -45,7 +45,7 @@ import Cubix.Language.Parametric.Syntax as P
 import Cubix.Transformations.Hoist.Custom
 import Cubix.Transformations.Variation
 
-class NoConstraint (fs :: [(* -> *) -> * -> *]) where
+class NoConstraint (fs :: Signature) where
 instance NoConstraint fs where
 
 type VarDeclFragment fs = ( SingleLocalVarDecl :-<: fs

--- a/src/Cubix/Transformations/TAC/Custom.hs
+++ b/src/Cubix/Transformations/TAC/Custom.hs
@@ -1,6 +1,7 @@
 {-# OPTIONS_HADDOCK hide #-}
 
 {-# LANGUAGE CPP                    #-}
+{-# LANGUAGE DataKinds              #-}
 {-# LANGUAGE FlexibleContexts       #-}
 {-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE GADTs                  #-}
@@ -30,7 +31,7 @@ import Data.Set ( Set )
 import qualified Data.Set as Set
 import Data.Proxy
 
-import Data.Comp.Multi ( Cxt(..), Term, Sum, All, unTerm, ContextS, project', proj, EqHF, project, runE, HFoldable, htoList, (:-<:), stripA, caseCxt, HFunctor)
+import Data.Comp.Multi ( Node, Cxt(..), Term, Sum, All, unTerm, ContextS, project', proj, EqHF, project, runE, HFoldable, htoList, (:-<:), stripA, caseCxt, HFunctor)
 import Data.Comp.Multi.Strategic ( Translate, crushtdT, addFail, promoteTF )
 import Data.Comp.Multi.Strategy.Classification ( DynCase, subterms )
 
@@ -162,7 +163,7 @@ instance RenderGuard MLuaSig where -- handle the insertF
 data ShouldHoist = ShouldHoist | ShouldntHoist | StopHoisting
   deriving ( Eq, Ord, Show )
 
-class ShouldHoistSelf' gs (f :: (* -> *) -> * -> *) where
+class ShouldHoistSelf' gs (f :: Node) where
   shouldHoistSelf' :: f (Term gs) l -> Maybe ShouldHoist
 
 instance {-# OVERLAPPABLE #-} ShouldHoistSelf' gs f where

--- a/src/Cubix/Transformations/TAC/Sorts.hs
+++ b/src/Cubix/Transformations/TAC/Sorts.hs
@@ -23,6 +23,7 @@ module Cubix.Transformations.TAC.Sorts (
 import Control.Monad ( MonadPlus )
 import Data.Proxy ( Proxy(..) )
 
+import Data.Comp.Multi ( Signature, Sort )
 import Data.Comp.Multi.Strategic ( GRewriteM, guardedT, guardBoolT, isSortT, isSortR, idR, failR )
 import Data.Comp.Multi.Strategy.Classification ( DynCase )
 
@@ -36,8 +37,8 @@ import Cubix.Language.Python.Parametric.Common as PCommon
 
 --------------------------------------------------------------------------------------
 
-type family ExpressionSort (fs :: [(* -> *) -> * -> *]) :: *
-type family BarrierSorts  (fs :: [(* -> *) -> * -> *]) :: [*]
+type family ExpressionSort (fs :: Signature) :: Sort
+type family BarrierSorts   (fs :: Signature) :: [Sort]
 
 #ifndef ONLY_ONE_LANGUAGE
 type instance ExpressionSort MCSig = CCommon.CExpressionL
@@ -60,7 +61,7 @@ type instance BarrierSorts   MLuaSig = '[LCommon.StatL, LCommon.FunBodyL]
 
 -- Subexp-to-tmp transform will run on all subexps of some "barrier sort" which are not contained in a sub barrier sort
 -- E.g.: Run all all exps in a statement which are not contained in a child statement
-class BarrierCheck' fs (l :: [*]) where
+class BarrierCheck' fs (l :: [Sort]) where
   barrierCheck' :: (MonadPlus m) => Proxy l -> GRewriteM m (TermLab fs)
 
 class BarrierCheck fs where

--- a/src/Cubix/Transformations/TAC/ToTAC.hs
+++ b/src/Cubix/Transformations/TAC/ToTAC.hs
@@ -36,7 +36,7 @@ import Control.Lens ( (&), (%~), (^.), (.~), makeLenses, view)
 import Control.Monad.Random ( MonadRandom, RandT, evalRandT )
 import Data.Constraint ( Dict(..) )
 
-import Data.Comp.Multi ( Cxt(..), project', EqHF, E(..), stripA, (:&:)(..), HTraversable, ShowHF, inject', (:-<:), All, HFoldable )
+import Data.Comp.Multi ( Signature, Cxt(..), project', EqHF, E(..), stripA, (:&:)(..), HTraversable, ShowHF, inject', (:-<:), All, HFoldable )
 import Data.Comp.Multi.Strategic ( GRewriteM, RewriteM, allbuR, allStateR, dynamicR,
            tryR, (<+), idR, guardedT, failR )
 import Data.Comp.Multi.Strategy.Classification ( DynCase, subterms, caseE )
@@ -156,7 +156,7 @@ instance (DefaultMultiLocalVarDeclCommonAttrs fs, InjF fs (ExpressionSort fs) Lo
 class    (DefaultLocalVarDeclAttrs fs, InjF fs (ExpressionSort fs) LocalVarInitL, InjF fs IdentL VarDeclBinderL) => ExtraSingleVarDeclConstraints fs
 instance (DefaultLocalVarDeclAttrs fs, InjF fs (ExpressionSort fs) LocalVarInitL, InjF fs IdentL VarDeclBinderL) => ExtraSingleVarDeclConstraints fs
 
-type CanTransTAC (fs :: [(* -> *) -> * -> *]) =
+type CanTransTAC (fs :: Signature) =
       ( DynCase (TermLab fs) (ExpressionSort fs)
       , DynCase (TermLab fs) (StatSort fs)
       , DynCase (TermLab fs) AssignL

--- a/src/Cubix/Transformations/TestCoverage.hs
+++ b/src/Cubix/Transformations/TestCoverage.hs
@@ -29,7 +29,7 @@ import qualified Data.Set as Set
 
 import Data.Text ( pack )
 
-import Data.Comp.Multi ( project', ShowHF, (:-<:), All, HFoldable )
+import Data.Comp.Multi ( Signature, project', ShowHF, (:-<:), All, HFoldable )
 import Data.Comp.Multi.Strategic ( GRewriteM, revAllbuR )
 import Data.Comp.Multi.Strategy.Classification ( caseDyn )
 
@@ -70,7 +70,7 @@ nextBlockId = do
   bb_counter -= 1
   return id
 
-class BlockCounterStart (fs :: [(* -> *) -> * -> *]) where
+class BlockCounterStart (fs :: Signature) where
   blockCounterStart :: Proxy fs -> Int
 
 -- Every language but Lua
@@ -184,7 +184,7 @@ instance {-# OVERLAPPING #-} ExcludeBasicBlock MJavaSig where
       excludeWhile _                                = False
 #endif
 
-class TrustReachability (fs :: [(* -> *) -> * -> *]) where
+class TrustReachability (fs :: Signature) where
   trustReachability :: Proxy fs -> Bool
 
 instance {-# OVERLAPPABLE #-} TrustReachability fs where

--- a/src/Cubix/Transformations/Variation.hs
+++ b/src/Cubix/Transformations/Variation.hs
@@ -34,7 +34,7 @@ module Cubix.Transformations.Variation (
 import Data.Proxy ( Proxy )
 import Data.Constraint ( Dict(..) )
 
-import Data.Comp.Multi ( (:-<:), CxtS, (:&:), Sum )
+import Data.Comp.Multi ( Node, Signature, Sort, (:-<:), CxtS, (:&:), Sum )
 
 import Cubix.Language.C.Parametric.Common
 import Cubix.Language.Java.Parametric.Common
@@ -44,7 +44,7 @@ import Cubix.Language.Python.Parametric.Common as P
 
 import Cubix.Language.Parametric.InjF
 
-type family StatSort (fs :: [(* -> *) -> * -> *]) :: *
+type family StatSort (fs :: Signature) :: Sort
 
 #ifndef ONLY_ONE_LANGUAGE
 type instance StatSort MCSig      = BlockItemL
@@ -76,12 +76,12 @@ instance DefaultMultiLocalVarDeclCommonAttrs MJSSig where
 type ContainsSingleDec fs = (SingleLocalVarDecl :-<: fs, OptLocalVarInit :-<: fs)
 
 -- Using this to add to MultiDecInsertion/SingleDecInsertion is an ugly hack
-type family StripAnn (f :: (* -> *) -> * -> *) :: (* -> *) -> * -> * where
+type family StripAnn (f :: Node) :: Node where
   StripAnn (f :&: a) = f
   StripAnn (Sum fs)  = Sum (StripAnnList fs)
   StripAnn x         = x
 
-type family StripAnnList (fs :: [(* -> *) -> * -> *]) :: [(* -> *) -> * -> *] where
+type family StripAnnList (fs :: [Node]) :: [Node] where
   StripAnnList (f ': fs) = StripAnn f ': StripAnnList fs
   StripAnnList '[]       = '[]
 


### PR DESCRIPTION
It turns out that it is possible to have kind synonyms in Haskell. Refactoring ahoy!

There are probably still many references lying around. Haskell provides no support in treating these kind synoyms opaquely