### PR TITLE
Add JavaScript source-position tracking tests

### DIFF
--- a/cabal.project.release
+++ b/cabal.project.release
@@ -3,6 +3,7 @@ packages:
     compdata
     comptrans
     compstrat
+    cubix-benchmarks
     cubix-examples
     cubix-solidity
     cubix-sui-move

--- a/cfg-test/Cubix/Language/C/Cfg/Test.hs
+++ b/cfg-test/Cubix/Language/C/Cfg/Test.hs
@@ -151,7 +151,7 @@ instance AssertCfgWellFormed MCSig CAssemblyOperand
 instance AssertCfgWellFormed MCSig CArraySize
 instance AssertCfgWellFormed MCSig CAlignmentSpecifier
 instance AssertCfgWellFormed MCSig Position
--- instance AssertCfgWellFormed MCSig FilePosition -- The type `FilePosition` does not exist anywhere in cubix or in language-c.
+instance AssertCfgWellFormed MCSig FilePosition
 instance AssertCfgWellFormed MCSig NodeInfo
 instance AssertCfgWellFormed MCSig Name
 
@@ -176,9 +176,9 @@ instance AssertCfgWellFormed MCSig SingleLocalVarDecl
 instance AssertCfgWellFormed MCSig OptLocalVarInit
 
 instance AssertCfgWellFormed MCSig CExpression where
-  assertCfgWellFormed t@(CCond test succ fail _ :&: _) = do
+  assertCfgWellFormed t@(CCond test succ fail :&: _) = do
     assertCfgCondOp (inject' t) test (S.extractF succ) fail
-  assertCfgWellFormed t@(CBinary op e1 e2 _ :&: _) = do
+  assertCfgWellFormed t@(CBinary op e1 e2 :&: _) = do
     case extractOp op of
       CLndOp -> assertCfgShortCircuit (inject' t) e1 e2
       CLorOp  -> assertCfgShortCircuit (inject' t) e1 e2
@@ -187,63 +187,63 @@ instance AssertCfgWellFormed MCSig CExpression where
     where extractOp :: MCTermLab CBinaryOpL -> CBinaryOp MCTerm CBinaryOpL
           extractOp (stripA -> project -> Just bp) = bp
 
-  assertCfgWellFormed t@(remA -> CComma es _) = assertCfgIsGeneric (inject' t) (map E $ extractF es)
+  assertCfgWellFormed t@(remA -> CComma es) = assertCfgIsGeneric (inject' t) (map E $ extractF es)
   -- Ignoring Assign
-  assertCfgWellFormed t@(remA -> CCast decs e _) = assertCfgIsGenericAuto (inject' t) [E decs, E e]
-  assertCfgWellFormed t@(remA -> CUnary _ e _) = assertCfgIsGeneric (inject' t) [E e]
-  assertCfgWellFormed t@(remA -> CSizeofExpr e _) = assertCfgIsGeneric (inject' t) [E e]
-  assertCfgWellFormed t@(remA -> CSizeofType dec _) = assertCfgIsGenericAuto (inject' t) [E dec]
-  assertCfgWellFormed t@(remA -> CAlignofExpr e _) = assertCfgIsGeneric (inject' t) [E e]
-  assertCfgWellFormed t@(remA -> CAlignofType dec _) = assertCfgIsGenericAuto (inject' t) [E dec]  
-  assertCfgWellFormed t@(remA -> CComplexReal e _) = assertCfgIsGeneric (inject' t) [E e]
-  assertCfgWellFormed t@(remA -> CComplexImag e _) = assertCfgIsGeneric (inject' t) [E e]
-  assertCfgWellFormed t@(remA -> CIndex i e _) = assertCfgIsGeneric (inject' t) [E i, E e]
-  assertCfgWellFormed t@(remA -> CIndex i e _) = assertCfgIsGeneric (inject' t) [E i, E e]
+  assertCfgWellFormed t@(remA -> CCast decs e) = assertCfgIsGenericAuto (inject' t) [E decs, E e]
+  assertCfgWellFormed t@(remA -> CUnary _ e) = assertCfgIsGeneric (inject' t) [E e]
+  assertCfgWellFormed t@(remA -> CSizeofExpr e) = assertCfgIsGeneric (inject' t) [E e]
+  assertCfgWellFormed t@(remA -> CSizeofType dec) = assertCfgIsGenericAuto (inject' t) [E dec]
+  assertCfgWellFormed t@(remA -> CAlignofExpr e) = assertCfgIsGeneric (inject' t) [E e]
+  assertCfgWellFormed t@(remA -> CAlignofType dec) = assertCfgIsGenericAuto (inject' t) [E dec]
+  assertCfgWellFormed t@(remA -> CComplexReal e) = assertCfgIsGeneric (inject' t) [E e]
+  assertCfgWellFormed t@(remA -> CComplexImag e) = assertCfgIsGeneric (inject' t) [E e]
+  assertCfgWellFormed t@(remA -> CIndex i e) = assertCfgIsGeneric (inject' t) [E i, E e]
+  assertCfgWellFormed t@(remA -> CIndex i e) = assertCfgIsGeneric (inject' t) [E i, E e]
   -- Ignoring CCall
-  assertCfgWellFormed t@(remA -> CMember e _ _ _) = assertCfgIsGeneric (inject' t) [E e]
+  assertCfgWellFormed t@(remA -> CMember e _ _) = assertCfgIsGeneric (inject' t) [E e]
   assertCfgWellFormed t@(remA -> CVar {}) = assertCfgIsGeneric (inject' t) []
-  assertCfgWellFormed t@(remA -> CConst {}) = assertCfgIsGeneric (inject' t) [] 
-  assertCfgWellFormed t@(remA -> CCompoundLit dec init _) = assertCfgIsGenericAuto (inject' t) [E dec, E init]
-  assertCfgWellFormed t@(remA -> CGenericSelection e es _) = assertCfgIsGenericAuto (inject' t) [E e, E es]  
-  assertCfgWellFormed t@(remA -> CStatExpr s _) = assertCfgIsGeneric (inject' t) (extractBlock s)
+  assertCfgWellFormed t@(remA -> CConst {}) = assertCfgIsGeneric (inject' t) []
+  assertCfgWellFormed t@(remA -> CCompoundLit dec init) = assertCfgIsGenericAuto (inject' t) [E dec, E init]
+  assertCfgWellFormed t@(remA -> CGenericSelection e es) = assertCfgIsGenericAuto (inject' t) [E e, E es]
+  assertCfgWellFormed t@(remA -> CStatExpr s) = assertCfgIsGeneric (inject' t) (extractBlock s)
   assertCfgWellFormed t@(remA -> CLabAddrExpr {}) = assertCfgIsGeneric (inject' t) []
   assertCfgWellFormed t@(remA -> CBuiltinExpr e) = assertCfgIsGenericAuto (inject' t) [E e]
   assertCfgWellFormed t = error $ "Impossible case: " ++ show (inject' t)
   
 instance AssertCfgWellFormed MCSig CStatement where
-  assertCfgWellFormed t@(remA -> CLabel _ stat _ _) =
+  assertCfgWellFormed t@(remA -> CLabel _ stat _) =
     assertCfgLabel (inject' t) (extractBlock' stat)
-  assertCfgWellFormed t@(remA -> CCase _ stat _) =
+  assertCfgWellFormed t@(remA -> CCase _ stat) =
     assertCfgSubtermsAuto (inject' t) (extractBlock stat)
-  assertCfgWellFormed t@(remA -> CCases _ _ stat _) =
+  assertCfgWellFormed t@(remA -> CCases _ _ stat) =
     assertCfgSubtermsAuto (inject' t) (extractBlock stat)
-  assertCfgWellFormed t@(remA -> CDefault stat _) =
+  assertCfgWellFormed t@(remA -> CDefault stat) =
     assertCfgSubtermsAuto (inject' t) (extractBlock stat)
-  assertCfgWellFormed t@(remA -> CExpr mexp _) =
+  assertCfgWellFormed t@(remA -> CExpr mexp) =
     case extractF mexp of
       Just e -> assertCfgIsGeneric (inject' t) [E e]
       Nothing -> assertCfgIsGeneric (inject' t) []
-  assertCfgWellFormed t@(CIf cond thn mels _ :&: _) =
+  assertCfgWellFormed t@(CIf cond thn mels :&: _) =
     case S.extractF mels of
       Just els -> assertCfgIfElse (inject' t) cond (extractBlock thn) (extractBlock els)
       Nothing  -> assertCfgIf (inject' t) cond (extractBlock thn)
-  assertCfgWellFormed t@(remA -> CWhile e b False _) =
+  assertCfgWellFormed t@(remA -> CWhile e b False) =
     assertCfgWhile (inject' t) e (extractBlock b)
-  assertCfgWellFormed t@(remA -> CWhile e b True _) =
+  assertCfgWellFormed t@(remA -> CWhile e b True) =
     assertCfgDoWhile (inject' t) (extractBlock b) e
-  assertCfgWellFormed t@(remA -> CGoto n _) =    
+  assertCfgWellFormed t@(remA -> CGoto n) =
     assertCfgGoto (inject' t) (nameString n)
-  assertCfgWellFormed t@(remA -> CGotoPtr e _) =    
+  assertCfgWellFormed t@(remA -> CGotoPtr e) =
     assertCfgReturn (inject' t) (Just e)
-  assertCfgWellFormed t@(remA -> CCont _) =
+  assertCfgWellFormed t@(remA -> CCont) =
     assertCfgContinue (inject' t)
-  assertCfgWellFormed t@(remA -> CBreak _) =
+  assertCfgWellFormed t@(remA -> CBreak) =
     assertCfgBreak (inject' t)
-  assertCfgWellFormed t@(remA -> CReturn e _) =
+  assertCfgWellFormed t@(remA -> CReturn e) =
     assertCfgReturn (inject' t) (S.extractF e)
-  assertCfgWellFormed t@(remA -> CSwitch exp body _) =
+  assertCfgWellFormed t@(remA -> CSwitch exp body) =
     assertCfgSwitch (inject' t) exp (extractBlock body)
-  assertCfgWellFormed t@(remA -> CAsm stmt _) = assertCfgIsGenericAuto (inject' t) [E stmt]
+  assertCfgWellFormed t@(remA -> CAsm stmt) = assertCfgIsGenericAuto (inject' t) [E stmt]
   assertCfgWellFormed t = error $ "Impossible case: " ++ show (inject' t)
 
 instance AssertCfgWellFormed MCSig CForInit
@@ -594,7 +594,7 @@ assertCfgGoto t labName = do
 
   where
     checkLab ::  E (TermLab MCSig) -> Bool
-    checkLab (E (project' -> Just (CLabel (nameString -> n) _ _ _ :&: _)))
+    checkLab (E (project' -> Just (CLabel (nameString -> n) _ _ :&: _)))
           | labName == n = True
           | otherwise = False
     checkLab _ = False
@@ -613,7 +613,7 @@ extractBlock :: TermLab MCSig CStatementL -> [E (TermLab MCSig)]
 extractBlock (project' -> Just (CLabeledBlock _ blk :&: _)) =
   case project' blk of
     Just (S.Block items _ :&: _) -> [E items]
-extractBlock t@(project' -> Just (remA -> CLabel _ stat _ _)) =
+extractBlock t@(project' -> Just (remA -> CLabel _ stat _)) =
   E t : extractBlock stat
 extractBlock t = [E t]
 

--- a/cubix-benchmarks/benchmarks/Benchmarks.hs
+++ b/cubix-benchmarks/benchmarks/Benchmarks.hs
@@ -53,12 +53,6 @@ fromRight :: Either a b -> b
 fromRight (Right x) = x
 fromRight (Left x) = error "Benchmarks.fromRight passed a Left"
 
-instance NFData (CLib.CTranslationUnit ()) where
-  rnf = rnf . show
-
-instance NFData (CLib.CTranslationUnit CLib.NodeInfo) where
-  rnf = rnf . show
-
 instance NFData JLib.CompilationUnit where
   rnf = rnf . show
 
@@ -83,14 +77,14 @@ instance NFData (Cfg f) where
 
 
 #ifndef ONLY_ONE_LANGUAGE
-getC :: FilePath -> IO ( CLib.CTranslUnit, CFull.CTerm CTranslationUnitL
+getC :: FilePath -> IO ( CLib.CTranslUnit, CFull.CTermOptAnn SourceSpan CTranslationUnitL
                        , MCTerm CTranslationUnitL, MCTermLab CTranslationUnitL
                        , Cfg MCSig)
 getC path = do
   raw <- fromRight <$> CParse.parse path
   gen <- mkConcurrentSupplyLabelGen -- OriginSynthetic
-  let fullTree = CFull.translate $ fmap (const ()) raw
-  let commTree = CCommon.translate fullTree
+  let fullTree = CFull.translate $ fmap (const Nothing) raw
+  let commTree = stripA $ CCommon.translate fullTree
   let labTree  = labelProg gen commTree
   return (raw, fullTree, commTree, labTree, makeCfg labTree)
 
@@ -115,7 +109,7 @@ getJS path = do
   raw <- JSLib.parseFile path
   gen <- mkConcurrentSupplyLabelGen -- OriginSynthetic
   let fullTree = JSFull.translate raw
-  let commTree = JSCommon.translate fullTree
+  let commTree = stripA $ JSCommon.translate $ JSFull.annotateWithSpans fullTree
   let labTree  = labelProg gen commTree
   return (raw, fullTree, commTree, labTree, makeCfg labTree)
 
@@ -180,7 +174,7 @@ main = do
                     , bench "removeAnnot"     $ nf (fmap (const ())) lib
                     , bench "pretty"          $ nf (show . CLib.pretty) lib
 
-                    , bench "transMod"        $ nf (CFull.translate . fmap (const ())) lib
+                    , bench "transMod"        $ nf (CFull.translate . fmap (const Nothing)) lib
                     , bench "transIps"        $ nf CCommon.translate full
                     , bench "label"           $ nf (labelProg gen) ips
                     , bench "cfg"             $ nf makeCfg lab
@@ -217,7 +211,7 @@ main = do
                     , bench "pretty"          $ nf (show . JSLib.prettyPrint) lib
 
                     , bench "transMod"        $ nf JSFull.translate lib
-                    , bench "transIps"        $ nf JSCommon.translate full
+                    , bench "transIps"        $ nf (JSCommon.translate . JSFull.annotateWithSpans) full
                     , bench "label"           $ nf (labelProg gen) ips
                     , bench "cfg"             $ nf makeCfg lab
                     , bench "hoist"           $ nf hoistDeclarations ips

--- a/cubix-examples/multi/Main.hs
+++ b/cubix-examples/multi/Main.hs
@@ -312,9 +312,14 @@ printAstAnn "python" file = do
   case mt of
     Nothing -> error "Parse failed"
     Just t  -> pPrintLightBg t
+printAstAnn "javascript" file = do
+  mt <- parseFileTrackSources @MJSSig file
+  case mt of
+    Nothing -> error "Parse failed"
+    Just t  -> pPrintLightBg t
 printAstAnn lang _ = error $
   "print-ast-ann is not yet wired up for language: " ++ lang
-  ++ " (currently supported: c, lua, python)"
+  ++ " (currently supported: c, javascript, lua, python)"
 
 --FIXME: I got lazy and just made a separate branch for IPT. Should be merged
 -- with other transformations

--- a/cubix.cabal
+++ b/cubix.cabal
@@ -272,9 +272,11 @@ test-suite unit-tests
   other-modules:
       Cubix.Analysis.NodePairsSpec
       Cubix.Language.C.SourcePosSpec
+      Cubix.Language.JavaScript.SourcePosSpec
       Cubix.Language.Lua.SourcePosSpec
       Cubix.Language.Parametric.SourcePos.Test
       Cubix.Language.Python.SourcePosSpec
+      Cubix.ParsePrettySpec
       Paths_cubix
   hs-source-dirs:
       test
@@ -332,6 +334,7 @@ test-suite unit-tests
     , filepath
     , hspec
     , language-c
+    , language-javascript
     , language-lua
     , language-python
     , mtl

--- a/devenv.local.nix
+++ b/devenv.local.nix
@@ -5,11 +5,11 @@
     "JAVA_TESTS" = lib.mkForce
       "/Users/jkoppel/research_large/other_frameworks/java-semantics/tests";
     "JS_TESTS" = lib.mkForce
-      "/Users/jkoppel/research_large/other_frameworks/javascript-semantics/test262/test/suite";
+      "/Users/jkoppel/conductor/workspaces/cubix/austin/.context/test262-kjs/test/suite/";
     "JS_PRELUDE" = lib.mkForce
-      "/Users/jkoppel/research_large/other_frameworks/javascript-semantics/prelude.js";
+      "/Users/jkoppel/conductor/workspaces/cubix/austin/.context/kjs/prelude.js";
     "JS_EXCLUDE" = lib.mkForce
-      "/Users/jkoppel/research_large/other_frameworks/java-semantics/list-invalid-tests.txt";
+      "/Users/jkoppel/conductor/workspaces/cubix/austin/.context/kjs/list-invalid-tests.txt";
     "PYTHON_TESTS" = lib.mkForce
       "/Users/jkoppel/research_large/other_frameworks/cpython/Lib/test";
     "GCC_TORTURE_TESTS" = lib.mkForce

--- a/package.yaml
+++ b/package.yaml
@@ -166,6 +166,7 @@ tests:
      - containers
      - cubix
      - hspec
+     - language-javascript
      - temporary
     build-tools:
      - hspec-discover

--- a/scripts/test_js.rb
+++ b/scripts/test_js.rb
@@ -7,6 +7,8 @@ TIMELIMIT = "45s"
 # Jakub 2025.06.12: Updated to match new Lua tests script, but I
 #                   have not run it.
 JS_TESTS = ENV["JS_TESTS"]
+JS_EXCLUDE = ENV["JS_EXCLUDE"]
+JS_PRELUDE = ENV["JS_PRELUDE"]
 RUNPROG = `cabal list-bin multi`.strip
 OUT_DIR = "tmp_js_" + transform
 
@@ -28,7 +30,7 @@ end
 
 Dir.mkdir OUT_DIR
 
-excluded_tests = File.read(JS_EXCLUDE").split(/\s+/)
+excluded_tests = File.read(JS_EXCLUDE).split(/\s+/)
 
 tests = `find #{JS_TESTS}ch{08,09,10,11,12,13,14} -name '*.js'`.split(/\s+/).select {|s| not (excluded_tests.index s) }
 
@@ -49,8 +51,12 @@ tests.each do |testfil|
   test_contents = File.read(testfil)
   positive = (nil == test_contents.index("@negative"))
 
-  # I had mysterious errors on big files using "<(" that "=(" seems to fix
-  system("zsh -c \"node =(cat #{JS_PRELUDE} #{testfil})\"")
+  # Feed via stdin so node runs as a script (this === globalThis), not
+  # as a CommonJS module (this === module.exports). The ES5 test262
+  # corpus uses `this.x` to mean "set on the global", which only
+  # works in script mode — historical Node defaulted there, modern
+  # Node defaults to module mode when invoked with a file argument.
+  system("cat #{JS_PRELUDE} #{testfil} | node")
 
   status = $?
 
@@ -90,8 +96,7 @@ tests.each do |testfil|
     f.puts(addTestCoverageArr(res))
   end
 
-  # I had mysterious errors on big files using "<(" that "=(" seems to fix
-  system("zsh -c \"node =(cat #{JS_PRELUDE} #{outfil})\"")
+  system("cat #{JS_PRELUDE} #{outfil} | node")
   status = $?
 
   if (status == 0) == positive

--- a/src/Cubix/Language/JavaScript/Parametric/Common.hs
+++ b/src/Cubix/Language/JavaScript/Parametric/Common.hs
@@ -33,7 +33,7 @@ import Cubix.Language.JavaScript.Parametric.Common.Semantics as Semantics
 import Cubix.Language.JavaScript.Parametric.Common.Types as Types
 import Cubix.Language.JavaScript.Parametric.Common.Trans as Trans
 import Cubix.Language.JavaScript.Parametric.Full as F
-        hiding ( translate, untranslate, JSIdent, iJSIdentName, jJSIdentName, iJSIdentNone, jJSIdentNone
+        hiding ( translate, translateStatement, translateExpression, untranslate, JSIdent, iJSIdentName, jJSIdentName, iJSIdentNone, jJSIdentNone
                , JSVarInitializer, iJSVarInit, jJSVarInit, iJSVarInitNone, jJSVarInitNone
                , JSFor, iJSFor, jJSFor, pattern JSFor', JSForIn, iJSForIn, jJSForIn, pattern JSForIn'
                , JSForVar, iJSForVar, jJSForVar, pattern JSForVar', JSForVarIn, iJSForVarIn, jJSForVarIn, pattern JSForVarIn'

--- a/src/Cubix/Language/JavaScript/Parametric/Common/Trans.hs
+++ b/src/Cubix/Language/JavaScript/Parametric/Common/Trans.hs
@@ -14,12 +14,14 @@ module Cubix.Language.JavaScript.Parametric.Common.Trans
   , untranslate
   ) where
 
+import Data.Default ( Default(..) )
 import Data.List ( (\\) )
 import Language.Haskell.TH.Syntax ( Type(ConT), Exp(VarE) )
 
 import Control.Lens ( (&), (%~), _1 )
 
-import Data.Comp.Multi ( Term, project, inject, unTerm, caseCxt, HFunctor(..), (:-<:), All, Sum )
+import Data.Comp.Multi ( Term, project, pattern (::&::), inject, unTerm, caseCxt, caseCxt'
+                       , HFunctor(..), (:-<:), All, Sum, (:&:)(..), AnnTerm )
 import Data.Comp.Multi.Show ()
 
 import Cubix.Language.JavaScript.Parametric.Common.Types
@@ -27,16 +29,25 @@ import qualified Cubix.Language.JavaScript.Parametric.Full as F
 import Cubix.Language.Parametric.Derive
 import Cubix.Language.Parametric.InjF
 import Cubix.Language.Parametric.Syntax
+import Cubix.Sin.Compdata.Annotation ( AnnotationInfo, getAnn )
 
 -------------------------------------------------------------------------------
 
+-- Unannotated placeholders used by the (unannotated) untranslate path.
 noAnn :: (F.JSAnnot :-<: fs, All HFunctor fs) => Term fs F.JSAnnotL
 noAnn = F.iJSNoAnnot
 
 semi :: (F.JSSemi :-<: fs, F.JSAnnot :-<: fs, All HFunctor fs) => Term fs F.JSSemiL
 semi = F.iJSSemi F.iJSNoAnnot
 
-jsCommaListToList :: F.JSTerm (F.JSCommaList l) -> [F.JSTerm l]
+-- Annotated placeholders used by the forward translate path.
+noAnnA :: forall fs a. (F.JSAnnot :-<: fs, Default a) => AnnTerm a fs F.JSAnnotL
+noAnnA = F.JSNoAnnot ::&:: def
+
+semiA :: forall fs a. (F.JSSemi :-<: fs, F.JSAnnot :-<: fs, Default a) => AnnTerm a fs F.JSSemiL
+semiA = F.JSSemi noAnnA ::&:: def
+
+jsCommaListToList :: (Default a) => F.JSTermAnn a (F.JSCommaList l) -> [F.JSTermAnn a l]
 jsCommaListToList (project -> Just (F.JSLCons xs _ x)) = jsCommaListToList xs ++ [x]
 jsCommaListToList (project -> Just (F.JSLOne x))       = [x]
 jsCommaListToList (project -> Just F.JSLNil)           = []
@@ -51,19 +62,20 @@ listToCommaList x = listToCommaList' $ reverse x -- They have left-associative l
 
 -------------------------------------------------------------------------------
 
-translate :: F.JSTerm l -> MJSTerm l
+translate :: (Default a, AnnotationInfo a) => F.JSTermAnn a l -> MJSTermAnn a l
 translate = trans . unTerm
 
-translate' :: (InjF MJSSig l l') => F.JSTerm l -> MJSTerm l'
-translate' = injF . translate
+translate' :: (InjF MJSSig l l', Default a, AnnotationInfo a) => F.JSTermAnn a l -> MJSTermAnn a l'
+translate' = injFAnnDef . translate
 
 class Trans f where
-  trans :: f F.JSTerm l -> MJSTerm l
+  trans :: (Default a, AnnotationInfo a) => (f :&: a) (F.JSTermAnn a) l -> MJSTermAnn a l
 
 instance {-# OVERLAPPING #-} (All Trans fs) => Trans (Sum fs) where
-  trans = caseCxt @Trans trans
+  trans = caseCxt' @Trans trans
 
-transDefault :: (HFunctor f, f :-<: MJSSig, f :-<: F.JSSig) => f F.JSTerm l -> MJSTerm l
+transDefault :: (HFunctor f, f :-<: MJSSig, f :-<: F.JSSig, Default a, AnnotationInfo a)
+             => (f :&: a) (F.JSTermAnn a) l -> MJSTermAnn a l
 transDefault = inject . hfmap translate
 
 instance {-# OVERLAPPABLE #-} (HFunctor f, f :-<: MJSSig, f :-<: F.JSSig) => Trans f where
@@ -73,93 +85,145 @@ instance {-# OVERLAPPABLE #-} (HFunctor f, f :-<: MJSSig, f :-<: F.JSSig) => Tra
 instance {-# OVERLAPPABLE #-} Trans F.JSVarInitializer where
   trans = error "JSVarInitializer found not within variable declaration"
 
-translateAssign :: F.JSTerm F.JSExpressionL -> F.JSTerm F.JSAssignOpL -> F.JSTerm F.JSExpressionL -> MJSTerm F.JSExpressionL
-translateAssign lhs op rhs = iAssign (injF $ translate lhs) op' (injF $ translate rhs)
+translateAssign :: (Default a, AnnotationInfo a)
+                => F.JSTermAnn a F.JSExpressionL
+                -> F.JSTermAnn a F.JSAssignOpL
+                -> F.JSTermAnn a F.JSExpressionL
+                -> a
+                -> MJSTermAnn a F.JSExpressionL
+translateAssign lhs op rhs a =
+    injFAnnDef $ Assign (injFAnnDef $ translate lhs) op' (injFAnnDef $ translate rhs) ::&:: a
   where
     op' = case op of
-      F.JSAssign' _ -> AssignOpEquals'
-      _             -> injF $ translate op
+      (F.JSAssign _ ::&:: opA) -> AssignOpEquals ::&:: opA
+      _                        -> injFAnnDef $ translate op
 
 -- This takes out things like "use strict";, which aren't really part of the computation,
 -- and have to be at the front
-splitDirectivePrelude :: [F.JSTerm F.JSStatementL] -> ([String], [F.JSTerm F.JSStatementL])
+splitDirectivePrelude
+  :: forall a. (Default a, AnnotationInfo a)
+  => [F.JSTermAnn a F.JSStatementL] -> ([String], [F.JSTermAnn a F.JSStatementL])
 splitDirectivePrelude []     = ([], [])
 splitDirectivePrelude (s:ss) = case toDirective s of
                                  Nothing  -> ([], s:ss)
                                  Just dir -> (splitDirectivePrelude ss) & _1 %~ (dir:)
   where
-    toDirective :: F.JSTerm F.JSStatementL -> Maybe String
+    toDirective :: F.JSTermAnn a F.JSStatementL -> Maybe String
     toDirective (project -> Just (F.JSExpressionStatement (project -> Just (F.JSStringLiteral _ str)) _)) = Just str
     toDirective _ = Nothing
 
-translateBlock :: F.JSTerm F.JSBlockL -> MJSTerm F.JSBlockL
-translateBlock (project -> Just (F.JSBlock _ ss _)) = iBlockWithPrelude dirPrelude block
+translateBlockStmts
+  :: forall a. (Default a, AnnotationInfo a)
+  => F.JSTermAnn a [F.JSStatementL] -> a -> MJSTermAnn a F.JSBlockL
+translateBlockStmts ss a = BlockWithPrelude dirPrelude block ::&:: a
   where
     (dirPrelude, blockStmts) = splitDirectivePrelude $ extractF ss
 
-    block = iBlock (insertF $ map (injF.translate) blockStmts) EmptyBlockEnd'
+    block :: MJSTermAnn a BlockL
+    block = Block (insertF $ map (injFAnnDef . translate) blockStmts) jEmptyBlockEnd ::&:: a
 
-translateFunCall :: F.JSTerm F.JSExpressionL -> F.JSTerm (F.JSCommaList F.JSExpressionL) -> MJSTerm FunctionCallL
-translateFunCall e args = FunctionCall' EmptyFunctionCallAttrs'
-                                        (injF $ translate e)
-                                        (FunctionArgumentList' $ insertF $ map (PositionalArgument' . injF . translate)
-                                                                               (jsCommaListToList args))
+translateBlock :: (Default a, AnnotationInfo a) => F.JSTermAnn a F.JSBlockL -> MJSTermAnn a F.JSBlockL
+translateBlock (F.JSBlock _ ss _ ::&:: a) = translateBlockStmts ss a
+
+translateFunCall
+  :: (Default a, AnnotationInfo a)
+  => F.JSTermAnn a F.JSExpressionL
+  -> F.JSTermAnn a (F.JSCommaList F.JSExpressionL)
+  -> a
+  -> MJSTermAnn a FunctionCallL
+-- The outer 'FunctionCall' carries the parent's whole-call annotation 'a',
+-- but the 'FunctionArgumentList' sub-node must NOT inherit it — that would
+-- make the args list claim a span covering the function expression too.
+-- We propagate the JSCommaList's own annotation instead, which spans only
+-- the arguments (empty arg lists fall back to 'def').
+translateFunCall e args a =
+  FunctionCall jEmptyFunctionCallAttrs
+               (injFAnnDef $ translate e)
+               (FunctionArgumentList (insertF $ map (\x -> PositionalArgument (injFAnnDef $ translate x) ::&:: def)
+                                                    (jsCommaListToList args))
+                  ::&:: getAnn args)
+    ::&:: a
 
 instance Trans F.JSExpression where
-  trans (F.JSIdentifier _ n)                     = iIdent n
-  trans (F.JSAssignExpression lhs op rhs)        = translateAssign lhs op rhs
-  trans (F.JSFunctionExpression _ a _ b _ block) = F.iJSFunctionExpression noAnn (translate a) noAnn (translate b) noAnn (translateBlock block)
-  trans (F.JSMemberExpression f _ args _)        = injF $ translateFunCall f args
-  trans (F.JSCallExpression   f _ args _)        = injF $ translateFunCall f args
-  trans x                                        = transDefault x
+  trans (F.JSIdentifier _ n :&: a)                     = injectFAnnDef (Ident n :&: a)
+  trans (F.JSAssignExpression lhs op rhs :&: a)        = translateAssign lhs op rhs a
+  trans (F.JSFunctionExpression _ na _ params _ block :&: a) =
+      F.JSFunctionExpression noAnnA (translate na) noAnnA (translate params) noAnnA (translateBlock block) ::&:: a
+  trans (F.JSMemberExpression f _ args _ :&: a)        = injFAnnDef $ translateFunCall f args a
+  trans (F.JSCallExpression   f _ args _ :&: a)        = injFAnnDef $ translateFunCall f args a
+  trans x                                              = transDefault x
 
-transIdent :: F.JSTerm F.JSIdentL -> MJSTerm IdentL
-transIdent (project -> (Just (F.JSIdentName _ n))) = Ident' n
-transIdent (project -> (Just F.JSIdentNone))       = error "JSIdentNone discovered where identifier was required"
+transIdent :: (Default a, AnnotationInfo a) => F.JSTermAnn a F.JSIdentL -> MJSTermAnn a IdentL
+transIdent (F.JSIdentName _ n ::&:: a) = Ident n ::&:: a
+transIdent (project -> (Just F.JSIdentNone)) = error "JSIdentNone discovered where identifier was required"
 
 
 instance Trans F.JSIdent where
-  trans (F.JSIdentName _ n) = injF $ Just' $ Ident' n
-  trans F.JSIdentNone       = injF $ (Nothing' :: MJSTerm (Maybe IdentL))
+  trans (F.JSIdentName _ n :&: a) = injFAnnDef $ JustF (Ident n ::&:: a) ::&:: a
+  trans (F.JSIdentNone     :&: a) = injFAnnDef $ (NothingF ::&:: a :: MJSTermAnn _ (Maybe IdentL))
 
-varInitToDecl :: F.JSTerm F.JSExpressionL -> MJSTerm SingleLocalVarDeclL
-varInitToDecl (project -> (Just (F.JSVarInitExpression lhs init))) =
-          SingleLocalVarDecl' EmptyLocalVarDeclAttrs' (injF $ translate lhs) rhs
+varInitToDecl :: (Default a, AnnotationInfo a) => F.JSTermAnn a F.JSExpressionL -> MJSTermAnn a SingleLocalVarDeclL
+varInitToDecl (F.JSVarInitExpression lhs init ::&:: a) =
+          SingleLocalVarDecl jEmptyLocalVarDeclAttrs (injFAnnDef $ translate lhs) rhs ::&:: a
   where
     rhs = case init of
-      F.JSVarInit' _ e -> JustLocalVarInit' $ injF $ translate e
-      F.JSVarInitNone' -> NoLocalVarInit'
+      (F.JSVarInit _ e ::&:: rA) -> JustLocalVarInit (injFAnnDef $ translate e) ::&:: rA
+      (F.JSVarInitNone ::&:: rA) -> NoLocalVarInit ::&:: rA
+      _ -> error "varInitToDecl: JSVarInitializer subterm is neither JSVarInit nor JSVarInitNone"
 
-extractVarDecls :: F.JSTerm (F.JSCommaList F.JSExpressionL) -> MJSTerm [SingleLocalVarDeclL]
+extractVarDecls
+  :: (Default a, AnnotationInfo a)
+  => F.JSTermAnn a (F.JSCommaList F.JSExpressionL) -> MJSTermAnn a [SingleLocalVarDeclL]
 extractVarDecls commaList = insertF $ map varInitToDecl exps
   where
     exps = jsCommaListToList commaList
 
-transCommaExpList :: F.JSTerm (F.JSCommaList F.JSExpressionL) -> MJSTerm [F.JSExpressionL]
+transCommaExpList
+  :: (Default a, AnnotationInfo a)
+  => F.JSTermAnn a (F.JSCommaList F.JSExpressionL) -> MJSTermAnn a [F.JSExpressionL]
 transCommaExpList = insertF . map translate . jsCommaListToList
 
-transParams :: F.JSTerm (F.JSCommaList F.JSIdentL) -> MJSTerm [FunctionParameterL]
-transParams args = insertF $ map (makeParam.transIdent) (jsCommaListToList args)
+transParams
+  :: (Default a, AnnotationInfo a)
+  => F.JSTermAnn a (F.JSCommaList F.JSIdentL) -> MJSTermAnn a [FunctionParameterL]
+transParams args = insertF $ map (makeParam . transIdent) (jsCommaListToList args)
   where
-    makeParam :: MJSTerm IdentL -> MJSTerm FunctionParameterL
-    makeParam n = PositionalParameter' EmptyParameterAttrs' n
+    makeParam :: (Default a, AnnotationInfo a) => MJSTermAnn a IdentL -> MJSTermAnn a FunctionParameterL
+    makeParam n = PositionalParameter jEmptyParameterAttrs n ::&:: def
 
 instance Trans F.JSStatement where
-  trans (F.JSVariable _ exprs _)      = iMultiLocalVarDecl EmptyMultiLocalVarDeclCommonAttrs'
-                                                         (extractVarDecls exprs)
-  trans (F.JSFor _ _ init _ exp _ upd _ s)      = iJSFor (transCommaExpList init) (transCommaExpList exp) (transCommaExpList upd) (translate s)
-  trans (F.JSForIn _ _ v op exp _ s)            = iJSForIn (translate v) (translate op) (translate exp) (translate s)
-  trans (F.JSForVar _ _ _ init _ exp _ upd _ s) = iJSForVar (extractVarDecls init) (transCommaExpList exp) (transCommaExpList upd) (translate s)
-  trans (F.JSForVarIn _ _ _ v op exp _ s)       = iJSForVarIn (varInitToDecl v) (translate op) (translate exp) (translate s)
-  trans (F.JSConstant _ _ _)                    = error "ES7 Const not supported"
-  trans (F.JSAssignStatement lhs op rhs s)      = F.iJSExpressionStatement (translateAssign lhs op rhs) semi
-  trans (F.JSFunction _ n _ args _ block _)     = iFunctionDef EmptyFunctionDefAttrs' (transIdent n) (transParams args) (injF $ translateBlock block)
-  trans (F.JSMethodCall f _ args _ _)           = F.iJSExpressionStatement (injF $ translateFunCall f args) semi
-  trans x                                       = transDefault x
+  trans (F.JSVariable _ exprs _ :&: a) =
+      injFAnnDef $ MultiLocalVarDecl jEmptyMultiLocalVarDeclCommonAttrs (extractVarDecls exprs) ::&:: a
+  trans (F.JSFor _ _ init _ exp _ upd _ s :&: a) =
+      injFAnnDef $ JSFor (transCommaExpList init) (transCommaExpList exp) (transCommaExpList upd) (translate s) ::&:: a
+  trans (F.JSForIn _ _ v op exp _ s :&: a) =
+      injFAnnDef $ JSForIn (translate v) (translate op) (translate exp) (translate s) ::&:: a
+  trans (F.JSForVar _ _ _ init _ exp _ upd _ s :&: a) =
+      injFAnnDef $ JSForVar (extractVarDecls init) (transCommaExpList exp) (transCommaExpList upd) (translate s) ::&:: a
+  trans (F.JSForVarIn _ _ _ v op exp _ s :&: a) =
+      injFAnnDef $ JSForVarIn (varInitToDecl v) (translate op) (translate exp) (translate s) ::&:: a
+  trans (F.JSConstant _ _ _ :&: _) = error "ES7 Const not supported"
+  -- The inner assign-expression's annotation is the parent's annotation
+  -- /minus/ the trailing semi position; we don't have a generic way to
+  -- subtract that off, so we fall back to 'def' here. The
+  -- 'JSExpressionStatement' wrapper still carries the statement-level
+  -- span, which is what a reparse-at-JSStatementL target needs.
+  trans (F.JSAssignStatement lhs op rhs _ :&: a) =
+      F.JSExpressionStatement (translateAssign lhs op rhs def) semiA ::&:: a
+  trans (F.JSFunction _ n _ args _ block _ :&: a) =
+      injFAnnDef $ FunctionDef jEmptyFunctionDefAttrs (transIdent n) (transParams args) (injFAnnDef $ translateBlock block) ::&:: a
+  -- See note on JSAssignStatement: the inner call-expression's
+  -- annotation comes out as 'def' rather than the parent's, so a
+  -- reparse target at JSExpressionL doesn't include the trailing
+  -- @;@ in its slice.
+  trans (F.JSMethodCall f _ args _ _ :&: a) =
+      F.JSExpressionStatement (injFAnnDef $ translateFunCall f args def) semiA ::&:: a
+  trans x = transDefault x
 
 instance Trans F.JSAST where
-  trans (F.JSAstProgram stmts _) = injF $ translateBlock (F.iJSBlock noAnn stmts noAnn)
-  trans x                        = transDefault x
+  trans (F.JSAstProgram stmts _ :&: a) =
+      injFAnnDef $ translateBlockStmts stmts a
+  trans x = transDefault x
 
 -------------------------------------------------------------------------------
 

--- a/src/Cubix/Language/JavaScript/Parametric/Common/Types.hs
+++ b/src/Cubix/Language/JavaScript/Parametric/Common/Types.hs
@@ -11,7 +11,7 @@ module Cubix.Language.JavaScript.Parametric.Common.Types where
 import Data.List ( (\\) )
 import Language.Haskell.TH ( mkName )
 
-import Data.Comp.Multi ( Term, project', project, HFunctor, (:-<:), All, CxtS, AnnCxtS )
+import Data.Comp.Multi ( Term, AnnTerm, project', project, HFunctor, (:-<:), All, CxtS, AnnCxtS )
 import Data.Comp.Trans ( runCompTrans, makeSumType )
 
 import Cubix.Language.Info
@@ -125,6 +125,9 @@ type instance InjectableSorts MJSSig MultiLocalVarDeclL = [JSStatementL, BlockIt
 
 type MJSTerm = Term MJSSig
 type MJSTermLab = TermLab MJSSig
+
+type MJSTermAnn    a = AnnTerm        a  MJSSig
+type MJSTermOptAnn a = AnnTerm (Maybe a) MJSSig
 
 type MJSCxt h a = CxtS h MJSSig a
 type MJSCxtA h a p = AnnCxtS p h MJSSig a

--- a/src/Cubix/Language/JavaScript/Parametric/Full/Trans.hs
+++ b/src/Cubix/Language/JavaScript/Parametric/Full/Trans.hs
@@ -1,7 +1,9 @@
 {-# OPTIONS_HADDOCK hide #-}
 
 {-# LANGUAGE CPP                     #-}
+{-# LANGUAGE ScopedTypeVariables     #-}
 {-# LANGUAGE TemplateHaskell         #-}
+{-# LANGUAGE TypeApplications        #-}
 {-# LANGUAGE UndecidableInstances    #-}
 
 #ifdef ONLY_ONE_LANGUAGE
@@ -9,7 +11,10 @@ module Cubix.Language.JavaScript.Parametric.Full.Trans () where
 #else
 module Cubix.Language.JavaScript.Parametric.Full.Trans (
     translate
+  , translateStatement
+  , translateExpression
   , untranslate
+  , annotateWithSpans
   ) where
 
 import Data.Typeable ( Typeable )
@@ -17,17 +22,28 @@ import Data.Typeable ( Typeable )
 import qualified Language.Haskell.TH as TH
 import qualified Language.JavaScript.Parser.AST as JS
 
-import Data.Comp.Multi ( Sum, All, caseCxt )
+import Data.Comp.Multi ( Sum, All, Cxt(..), HFunctor(..), (:&:)(..), caseCxt, cata, inj, proj )
+import Data.Comp.Multi.Algebra ( Alg )
+import Data.Comp.Multi.Annotation ( pattern (::&::) )
+import Data.Comp.Multi.HFoldable ( hfoldMap )
 import Data.Comp.Trans ( runCompTrans, deriveTrans, deriveUntrans )
 
+import Cubix.Language.Info ( SourcePos(..), SourceSpan(..), mkSourceSpan )
 import Cubix.Language.JavaScript.Parametric.Full.Names
 import Cubix.Language.JavaScript.Parametric.Full.Types
 import Cubix.Language.Parametric.Syntax.Functor
+import Cubix.Sin.Compdata.Annotation ( getAnn )
 
 runCompTrans $ deriveTrans origASTTypes (TH.ConT ''JSTerm)
 
 translate :: JS.JSAST -> JSTerm JSASTL
 translate = trans
+
+translateStatement :: JS.JSStatement -> JSTerm JSStatementL
+translateStatement = trans
+
+translateExpression :: JS.JSExpression -> JSTerm JSExpressionL
+translateExpression = trans
 
 instance (Trans c l) => Trans (JS.JSCommaList c) (JSCommaList l) where
   trans (JS.JSLCons a b c) = riJSLCons (trans a) (trans b) (trans c)
@@ -73,4 +89,144 @@ instance Untrans MaybeF where
 
 instance (All Untrans fs) => Untrans (Sum fs) where
   untrans = caseCxt @Untrans untrans
+
+-- @language-javascript@ records token start positions on 'JS.JSAnnot'
+-- sub-sort nodes rather than as the top-level @a@ parameter that
+-- @comptrans@ threads for other languages. 'annotateWithSpans'
+-- lifts those positions to a 'Maybe SourceSpan' annotation per node
+-- and collapses every 'JSAnnot' to 'JSNoAnnot' so that 'TokenPn'
+-- coordinates (which differ between in-context and slice-isolation
+-- parses) don't confuse 'stripA'-based comparisons downstream.
+annotateWithSpans :: JSTerm l -> JSTermAnn (Maybe SourceSpan) l
+annotateWithSpans = clearEmptyAnn . cata alg
+  where
+    alg :: Alg (Sum JSSig) (JSTermAnn (Maybe SourceSpan))
+    alg f
+      | Just (JSAnnot pn _) <- proj @JSAnnot f
+      = Term (inj JSNoAnnot :&: tokenPosnSpan pn)
+      | otherwise
+      = Term (f :&: maybe childSpan (\w -> extendSpanBy (w - 1) childSpan) (tokenWidth f))
+      where
+        childSpan = unionSpans (hfoldMap (\c -> [getAnn c]) f)
+
+    tokenPosnSpan :: JSTermAnn (Maybe SourceSpan) TokenPosnL -> Maybe SourceSpan
+    tokenPosnSpan (TokenPn _ row col ::&:: _)
+      | (row, col) /= (0, 0) = Just (mkSourceSpan "" (row, col) (row, col))
+    tokenPosnSpan _          = Nothing
+
+    -- Atomic token widths: 'JSAnnot' only records start positions, so
+    -- for nodes whose textual payload is observable we extend the
+    -- synthesised end by the payload's length.
+    tokenWidth f
+      | Just e <- proj @JSExpression f = jsExprTokenWidth e
+      | Just p <- proj @JSPropertyName f = jsPropertyNameWidth p
+      | Just op <- proj @JSUnaryOp f   = Just (jsUnaryOpWidth op)
+      | Just op <- proj @JSBinOp f     = Just (jsBinOpWidth op)
+      | Just op <- proj @JSAssignOp f  = Just (jsAssignOpWidth op)
+      | Just (JSIdentName _ s) <- proj @JSIdent f = Just (length s)
+      | otherwise = Nothing
+
+    jsExprTokenWidth :: JSExpression e l -> Maybe Int
+    jsExprTokenWidth (JSIdentifier    _ s) = Just (length s)
+    jsExprTokenWidth (JSDecimal       _ s) = Just (length s)
+    jsExprTokenWidth (JSLiteral       _ s) = Just (length s)
+    jsExprTokenWidth (JSHexInteger    _ s) = Just (length s)
+    jsExprTokenWidth (JSOctal         _ s) = Just (length s)
+    jsExprTokenWidth (JSStringLiteral _ s) = Just (length s)
+    jsExprTokenWidth (JSRegEx         _ s) = Just (length s)
+    jsExprTokenWidth _                     = Nothing
+
+    jsPropertyNameWidth :: JSPropertyName e l -> Maybe Int
+    jsPropertyNameWidth (JSPropertyIdent  _ s) = Just (length s)
+    jsPropertyNameWidth (JSPropertyString _ s) = Just (length s)
+    jsPropertyNameWidth (JSPropertyNumber _ s) = Just (length s)
+
+    jsUnaryOpWidth :: JSUnaryOp e l -> Int
+    jsUnaryOpWidth (JSUnaryOpDecr   _) = 2
+    jsUnaryOpWidth (JSUnaryOpDelete _) = 6
+    jsUnaryOpWidth (JSUnaryOpIncr   _) = 2
+    jsUnaryOpWidth (JSUnaryOpMinus  _) = 1
+    jsUnaryOpWidth (JSUnaryOpNot    _) = 1
+    jsUnaryOpWidth (JSUnaryOpPlus   _) = 1
+    jsUnaryOpWidth (JSUnaryOpTilde  _) = 1
+    jsUnaryOpWidth (JSUnaryOpTypeof _) = 6
+    jsUnaryOpWidth (JSUnaryOpVoid   _) = 4
+
+    jsBinOpWidth :: JSBinOp e l -> Int
+    jsBinOpWidth (JSBinOpAnd       _) = 2
+    jsBinOpWidth (JSBinOpBitAnd    _) = 1
+    jsBinOpWidth (JSBinOpBitOr     _) = 1
+    jsBinOpWidth (JSBinOpBitXor    _) = 1
+    jsBinOpWidth (JSBinOpDivide    _) = 1
+    jsBinOpWidth (JSBinOpEq        _) = 2
+    jsBinOpWidth (JSBinOpGe        _) = 2
+    jsBinOpWidth (JSBinOpGt        _) = 1
+    jsBinOpWidth (JSBinOpIn        _) = 2
+    jsBinOpWidth (JSBinOpInstanceOf _) = 10
+    jsBinOpWidth (JSBinOpLe        _) = 2
+    jsBinOpWidth (JSBinOpLsh       _) = 2
+    jsBinOpWidth (JSBinOpLt        _) = 1
+    jsBinOpWidth (JSBinOpMinus     _) = 1
+    jsBinOpWidth (JSBinOpMod       _) = 1
+    jsBinOpWidth (JSBinOpNeq       _) = 2
+    jsBinOpWidth (JSBinOpOr        _) = 2
+    jsBinOpWidth (JSBinOpPlus      _) = 1
+    jsBinOpWidth (JSBinOpRsh       _) = 2
+    jsBinOpWidth (JSBinOpStrictEq  _) = 3
+    jsBinOpWidth (JSBinOpStrictNeq _) = 3
+    jsBinOpWidth (JSBinOpTimes     _) = 1
+    jsBinOpWidth (JSBinOpUrsh      _) = 3
+
+    jsAssignOpWidth :: JSAssignOp e l -> Int
+    jsAssignOpWidth (JSAssign       _) = 1
+    jsAssignOpWidth (JSTimesAssign  _) = 2
+    jsAssignOpWidth (JSDivideAssign _) = 2
+    jsAssignOpWidth (JSModAssign    _) = 2
+    jsAssignOpWidth (JSPlusAssign   _) = 2
+    jsAssignOpWidth (JSMinusAssign  _) = 2
+    jsAssignOpWidth (JSLshAssign    _) = 3
+    jsAssignOpWidth (JSRshAssign    _) = 3
+    jsAssignOpWidth (JSUrshAssign   _) = 4
+    jsAssignOpWidth (JSBwAndAssign  _) = 2
+    jsAssignOpWidth (JSBwXorAssign  _) = 2
+    jsAssignOpWidth (JSBwOrAssign   _) = 2
+
+    -- JSAnnot nodes carry punctuation token positions that parent
+    -- spans need during the bottom-up synthesis above, but the
+    -- collapsed JSNoAnnot placeholders have no textual payload of
+    -- their own. Rewrite them to degenerate empty spans after the
+    -- parent spans have already been computed.
+    clearEmptyAnn :: JSTermAnn (Maybe SourceSpan) l' -> JSTermAnn (Maybe SourceSpan) l'
+    clearEmptyAnn (Term (node :&: a)) =
+      Term (node' :&: if isNoAnnot node' then fmap emptySpan a else a)
+      where
+        node' = hfmap clearEmptyAnn node
+
+    isNoAnnot node = case proj @JSAnnot node of
+      Just JSNoAnnot -> True
+      _              -> False
+
+    emptySpan :: SourceSpan -> SourceSpan
+    emptySpan (SourceSpan s _) = SourceSpan s (prevPos s)
+
+    prevPos :: SourcePos -> SourcePos
+    prevPos (SourcePos f r c) = SourcePos f r (c - 1)
+
+extendSpanBy :: Int -> Maybe SourceSpan -> Maybe SourceSpan
+extendSpanBy n (Just (SourceSpan s (SourcePos f r c))) =
+  Just (SourceSpan s (SourcePos f r (c + max 0 n)))
+extendSpanBy _ Nothing = Nothing
+
+unionSpans :: [Maybe SourceSpan] -> Maybe SourceSpan
+unionSpans = foldr step Nothing
+  where
+    step Nothing s = s
+    step s Nothing = s
+    step (Just (SourceSpan s1 e1)) (Just (SourceSpan s2 e2)) =
+      Just $ SourceSpan (minPos s1 s2) (maxPos e1 e2)
+
+    minPos a@(SourcePos _ r1 c1) b@(SourcePos _ r2 c2) =
+      if (r1, c1) <= (r2, c2) then a else b
+    maxPos a@(SourcePos _ r1 c1) b@(SourcePos _ r2 c2) =
+      if (r1, c1) >= (r2, c2) then a else b
 #endif

--- a/src/Cubix/Language/JavaScript/Parametric/Full/Types.hs
+++ b/src/Cubix/Language/JavaScript/Parametric/Full/Types.hs
@@ -12,7 +12,7 @@ module Cubix.Language.JavaScript.Parametric.Full.Types where
 import qualified Data.Set as Set
 import Data.Type.Equality ( (:~:)(..), gcastWith )
 
-import Data.Comp.Multi ( (:<:), inject, project, Cxt, Term )
+import Data.Comp.Multi ( (:<:), AnnTerm, inject, project, Cxt, Term )
 import Data.Comp.Multi.Derive ( derive, makeConstrNameHF, makeHFunctor, makeHTraversable, makeHFoldable,
                                     makeEqHF, makeShowHF, makeOrdHF )
 
@@ -99,6 +99,9 @@ do let specialSigNames = [''JSCommaListF, ''JSCommaTrailingListF]
 
 type JSTerm    = Term JSSig
 type JSTermLab l = TermLab JSSig l
+
+type JSTermAnn    a = AnnTerm        a  JSSig
+type JSTermOptAnn a = AnnTerm (Maybe a) JSSig
 
 -- Phase restriction makes eliminating redundancy hard
 jsSigNames :: [TH.Name]

--- a/src/Cubix/ParsePretty.hs
+++ b/src/Cubix/ParsePretty.hs
@@ -14,6 +14,7 @@ module Cubix.ParsePretty (
   , parseC
   , parseJava
   , parseJavaScript
+  , parseJavaScriptTrackSources
   , parsePython
 
   , prettyC
@@ -27,11 +28,11 @@ module Cubix.ParsePretty (
 import Control.Monad ( liftM, (>=>) )
 import Control.Monad.Identity ( runIdentity )
 
-import Data.Comp.Multi ( Term, AnnTerm, stripA, ann )
+import Data.Comp.Multi ( Term, AnnTerm, Cxt(..), Sum, HFunctor, hfmap, stripA, ann, (:&:)(..) )
 import Data.Comp.Multi.Strategic ( RewriteM, allbuR, promoteR )
 import Data.Comp.Multi.Strategy.Classification ( DynCase, fromDynProj )
 
-import qualified Data.Text.IO as Text
+import qualified Data.Text as T
 
 import qualified Language.C as C
 import qualified Language.C.Data.Node as C ( getLastTokenPos )
@@ -59,9 +60,6 @@ import           Cubix.Language.Lua.Parametric.Common        as LCommon
 import qualified Cubix.Language.Lua.Parametric.Full          as LFull
 import           Cubix.Language.Python.Parametric.Common     as PCommon
 import qualified Cubix.Language.Python.Parametric.Full       as PFull
-
-import qualified Data.Text as T (unpack)
-import qualified Cubix.Language.Java.Parametric.Common as Python
 
 ---------------------------------------------------------------------------------------------
 
@@ -223,8 +221,18 @@ instance Pretty MJavaSig where pretty = prettyJava
 --------------------------- JavaScript ----------------------------
 -------------------------------------------------------------------
 
+parseJavaScriptTrackSources
+  :: FilePath -> IO (Maybe (MJSTermAnn (Maybe SourceSpan) JSASTL))
+parseJavaScriptTrackSources path = do
+  tree <- JS.parseFile path
+  return $ Just $ fillFilename path
+                $ JSCommon.translate
+                $ JSFull.annotateWithSpans
+                $ JSFull.translate tree
+
 parseJavaScript :: FilePath -> IO (Maybe (MJSTerm JSASTL))
-parseJavaScript path = liftM (Just . JSCommon.translate . normalizeJS . JSFull.translate) $ JS.parseFile path
+parseJavaScript path =
+  liftM (Just . stripA . JSCommon.translate . ann () . normalizeJS . JSFull.translate) $ JS.parseFile path
   where
     normalizeJS :: JSFull.JSTerm JSASTL -> JSFull.JSTerm JSASTL
     normalizeJS t = runIdentity $ allbuR (promoteR normalizeSemi >=> promoteR normalizeAnno) t
@@ -241,6 +249,7 @@ prettyJavaScript =  JS.prettyPrint . JSFull.untranslate . JSCommon.untranslate
 
 type instance RootSort MJSSig = JSASTL
 instance ParseFile MJSSig where parseFile = parseJavaScript
+instance ParseFileTrackSources MJSSig where parseFileTrackSources = parseJavaScriptTrackSources
 instance Pretty MJSSig where pretty = prettyJavaScript
 
 -------------------------------------------------------------------
@@ -269,5 +278,22 @@ type instance RootSort MPythonSig = PCommon.ModuleL
 instance ParseFile MPythonSig where parseFile = fmap (fmap stripA) . parsePython
 instance ParseFileTrackSources MPythonSig where parseFileTrackSources = parsePython
 instance Pretty MPythonSig where pretty = prettyPython
+
+-- | Stamp a filename onto every 'SourceSpan' annotation in the tree.
+-- 'language-javascript' carries token positions but not file names, so
+-- 'annotateWithSpans' emits spans with @_sourceFile = ""@; we fix that
+-- up here in one tree pass instead of re-scanning the source bytes.
+fillFilename
+  :: forall fs l. HFunctor (Sum fs)
+  => FilePath
+  -> AnnTerm (Maybe SourceSpan) fs l
+  -> AnnTerm (Maybe SourceSpan) fs l
+fillFilename path = go
+  where
+    go :: forall l'. AnnTerm (Maybe SourceSpan) fs l' -> AnnTerm (Maybe SourceSpan) fs l'
+    go (Term (node :&: a)) = Term (hfmap go node :&: fmap setFile a)
+
+    setFile (SourceSpan s e) =
+      SourceSpan (s { _sourceFile = path }) (e { _sourceFile = path })
 
 #endif

--- a/test/Cubix/Language/JavaScript/SourcePosSpec.hs
+++ b/test/Cubix/Language/JavaScript/SourcePosSpec.hs
@@ -1,0 +1,141 @@
+-- | JavaScript plug-in for the language-agnostic source-position spec.
+--
+-- All the property logic lives in
+-- "Cubix.Language.Parametric.SourcePos.Test"; this module supplies the
+-- JavaScript-specific bits: snippets to exercise, how to parse a file,
+-- and how to enumerate parser-able subterms (JSStatement, JSExpression)
+-- along with the reparser chain
+-- @parseProgram\/parseExpression → Full.translateStatement\/translateExpression → Full.annotateWithSpans → Common.translate@.
+--
+-- See 'Cubix.Language.JavaScript.Parametric.Full.Trans.annotateWithSpans'
+-- for how 'Maybe SourceSpan' annotations are derived from
+-- @language-javascript@'s 'TokenPosn' nodes, and why we collapse
+-- @JSAnnot@ subterms before slice comparisons.
+
+module Cubix.Language.JavaScript.SourcePosSpec (spec) where
+
+import Control.Monad                         (unless, when)
+import Data.List                             (sort)
+import Data.Maybe                            (mapMaybe)
+import Data.Text                             (Text)
+import Data.Text qualified                   as T
+import System.Directory                      (doesDirectoryExist, listDirectory)
+import System.FilePath                       ((</>), takeExtension)
+import Test.Hspec
+
+import Language.JavaScript.Parser qualified            as JS
+import Language.JavaScript.Parser.Grammar5 qualified   as JS
+import Language.JavaScript.Parser.Parser qualified     as JS (parseUsing)
+
+import Data.Comp.Multi                       (E (..))
+import Data.Comp.Multi.Generic               qualified as Generic
+import Data.Comp.Multi.Strategy.Classification (dynProj, isSort)
+
+import Cubix.Language.Info                   (SourceSpan)
+import Cubix.Language.JavaScript.Parametric.Common (MJSSig, MJSTermAnn)
+import Cubix.Language.JavaScript.Parametric.Common qualified as JSCommon
+import Cubix.Language.JavaScript.Parametric.Full qualified as JSFull
+import Cubix.ParsePretty                     (parseFileTrackSources)
+import Cubix.Sin.Compdata.Annotation         (getAnn)
+
+import Cubix.Language.Parametric.SourcePos.Test
+
+spec :: Spec
+spec = do
+  testFiles <- runIO discoverInputFiles
+  sourcePosSpec (jsKit testFiles)
+
+jsKit :: [FilePath] -> SourcePosKit MJSSig JSFull.JSASTL
+jsKit testFiles = SourcePosKit
+  { kitLanguageName   = "JavaScript"
+  , kitSnippets       = jsSnippets
+  , kitTestFiles      = testFiles
+  , kitParseFile      = parseFileTrackSources @MJSSig
+  , kitReParseTargets = jsReParseTargets
+    -- JavaScript parsing is context-free; reparse mismatches indicate
+    -- real problems and should fail loudly.
+  , kitFileReparseIsBestEffort = False
+  }
+
+-- | Discover the @.js@ files in @input-files/javascript/@ (including
+-- the @ipt/@ subdirectory).
+discoverInputFiles :: IO [FilePath]
+discoverInputFiles = (++) <$> listJsFiles "input-files/javascript"
+                          <*> listJsFiles "input-files/javascript/ipt"
+
+listJsFiles :: FilePath -> IO [FilePath]
+listJsFiles dir = do
+  exists <- doesDirectoryExist dir
+  unless exists $
+    error $ "JavaScript test corpus directory missing — expected to find " ++ dir
+  entries <- listDirectory dir
+  let files = sort [ dir </> e | e <- entries, takeExtension e == ".js" ]
+  when (null files) $
+    error $ "JavaScript test corpus directory is empty — no .js files in " ++ dir
+  pure files
+
+jsSnippets :: [(String, String)]
+jsSnippets =
+  [ ("assign-and-binop", "var x = 42;\nvar y = x + 1;\n")
+  , ("if-else",          "if (x) { y = 1; } else { y = 2; }\n")
+  , ("while-loop",       "while (i < 10) { i = i + 1; }\n")
+  , ("function-decl",    "function f(a, b) { return a + b; }\n")
+  , ("method-call",      "x.foo(1, 2);\n")
+  , ("nested-array",     "var t = [1, 2, [3, 4]];\n")
+  , ("postfix-inc",      "i++;\n")
+  , ("leading-space",    "\n  var x = 1;\n")
+  , ("string-literal",   "var s = \"hello\";\n")
+  ]
+
+-- | Pick out subterms at sorts that @language-javascript@ can parse
+-- standalone (JSAST, JSStatement, JSExpression).
+jsReParseTargets
+  :: MJSTermAnn (Maybe SourceSpan) l
+  -> [ReParseTarget MJSSig]
+jsReParseTargets root = mapMaybe targetOf (Generic.subterms root)
+  where
+    targetOf
+      :: E (MJSTermAnn (Maybe SourceSpan)) -> Maybe (ReParseTarget MJSSig)
+    targetOf (E sub)
+      | Just sp <- getAnn sub, isDegenerateSpan sp = Nothing
+      | Just sp <- getAnn sub
+      , isSort @JSFull.JSASTL sub
+      , Just sub' <- dynProj @_ @JSFull.JSASTL sub = Just (RPT sp reparseProgram sub')
+      | Just sp <- getAnn sub
+      , isSort @JSFull.JSStatementL sub
+      , Just sub' <- dynProj @_ @JSFull.JSStatementL sub  = Just (RPT sp reparseStatement sub')
+      | Just sp <- getAnn sub
+      , isSort @JSFull.JSExpressionL sub
+      , Just sub' <- dynProj @_ @JSFull.JSExpressionL sub = Just (RPT sp reparseExpression sub')
+      | otherwise = Nothing
+
+reparseProgram :: Text -> Either String (MJSTermAnn (Maybe SourceSpan) JSFull.JSASTL)
+reparseProgram t = case JS.parse (T.unpack t) "<slice>" of
+  Left err  -> Left $ "parser error: " ++ err
+  Right ast -> Right $ JSCommon.translate
+                     $ JSFull.annotateWithSpans
+                     $ JSFull.translate ast
+
+-- @parseStatement@ implements ASI at the end of input, which causes it
+-- to reject trailing @;@ tokens that are valid as the statement's own
+-- terminator. @parseProgram@ doesn't have that quirk, so we use it
+-- here and require the result to be exactly one statement.
+reparseStatement :: Text -> Either String (MJSTermAnn (Maybe SourceSpan) JSFull.JSStatementL)
+reparseStatement t = case JS.parse (T.unpack t) "<slice>" of
+  Left err  -> Left $ "parser error: " ++ err
+  Right (JS.JSAstProgram [s] _) ->
+    Right $ JSCommon.translate
+          $ JSFull.annotateWithSpans
+          $ JSFull.translateStatement s
+  Right (JS.JSAstProgram ss _) ->
+    Left $ "expected exactly one statement, got " ++ show (length ss)
+  Right other -> Left $ "expected JSAstProgram, got " ++ show other
+
+reparseExpression :: Text -> Either String (MJSTermAnn (Maybe SourceSpan) JSFull.JSExpressionL)
+reparseExpression t = case JS.parseUsing JS.parseExpression (T.unpack t) "<slice>" of
+  Left err  -> Left $ "parser error: " ++ err
+  Right (JS.JSAstExpression e _) ->
+    Right $ JSCommon.translate
+          $ JSFull.annotateWithSpans
+          $ JSFull.translateExpression e
+  Right other -> Left $ "expected JSAstExpression, got " ++ show other

--- a/test/Cubix/Language/Parametric/SourcePos/Test.hs
+++ b/test/Cubix/Language/Parametric/SourcePos/Test.hs
@@ -348,7 +348,9 @@ checkReparse source (RPT sp reparse original) =
 -- column positions. For indentation-sensitive languages a kit may need
 -- to dedent before reparsing — see 'Cubix.Language.Python.SourcePosSpec'.
 sliceSpan :: Text -> SourceSpan -> Text
-sliceSpan src (SourceSpan (SourcePos _ r1 c1) (SourcePos _ r2 c2)) =
+sliceSpan src sp@(SourceSpan (SourcePos _ r1 c1) (SourcePos _ r2 c2))
+  | isDegenerateSpan sp = T.empty
+  | otherwise =
   let s = rowColToOffset r1 c1
       e = rowColToOffset r2 c2 + 1
   in T.take (e - s) (T.drop s src)

--- a/test/Cubix/ParsePrettySpec.hs
+++ b/test/Cubix/ParsePrettySpec.hs
@@ -1,0 +1,60 @@
+module Cubix.ParsePrettySpec (spec) where
+
+import Data.Comp.Multi                       (E (..), project)
+import Data.Comp.Multi.Generic               qualified as Generic
+import Data.Comp.Multi.Strategy.Classification (dynProj, isSort)
+import Data.Text                             qualified as T
+import Data.Text.IO                          qualified as T
+import System.IO.Temp (writeSystemTempFile)
+import Test.Hspec
+
+import Cubix.Language.Info                   (SourceSpan)
+import Cubix.Language.JavaScript.Parametric.Common (MJSSig, MJSTermAnn)
+import Cubix.Language.JavaScript.Parametric.Full qualified as JSFull
+import Cubix.Language.Parametric.SourcePos.Test (sliceSpan)
+import Cubix.ParsePretty (parseFileTrackSources, parseJavaScript)
+import Cubix.Sin.Compdata.Annotation         (getAnn)
+
+spec :: Spec
+spec =
+  describe "parseJavaScript" $ do
+    it "normalizes explicit JavaScript semicolons the same as ASI" $ do
+      explicitSemi <- parseJavaScript =<< writeSystemTempFile "explicit-semi.js" "i++;\n"
+      automaticSemi <- parseJavaScript =<< writeSystemTempFile "automatic-semi.js" "i++\n"
+      explicitSemi `shouldBe` automaticSemi
+
+    it "gives JSNoAnnot empty slices without truncating property identifiers" $ do
+      path <- writeSystemTempFile "object-literal.js" "({toString: 0});\n"
+      Just t <- parseFileTrackSources @MJSSig path
+      src <- T.readFile path
+
+      let noAnnSlices = [ sliceSpan src sp
+                        | E sub <- Generic.subterms t
+                        , Just sp <- [getAnn sub]
+                        , isSort @JSFull.JSAnnotL sub
+                        , Just sub' <- [dynProj @_ @JSFull.JSAnnotL sub]
+                        , Just JSFull.JSNoAnnot <- [project sub']
+                        ]
+
+      noAnnSlices `shouldSatisfy` (not . null)
+      noAnnSlices `shouldSatisfy` all T.null
+
+      propertySlices t src `shouldContain`
+        [("toString", T.pack "toString")]
+
+propertySlices
+  :: MJSTermAnn (Maybe SourceSpan) l
+  -> T.Text
+  -> [(String, T.Text)]
+propertySlices root src =
+  [ (name, sliceSpan src sp)
+  | E sub <- Generic.subterms root
+  , Just sp <- [getAnn sub]
+  , isSort @JSFull.JSPropertyNameL sub
+  , Just sub' <- [dynProj @_ @JSFull.JSPropertyNameL sub]
+  , Just prop <- [project sub']
+  , name <- case prop of
+      JSFull.JSPropertyIdent _ s  -> [s]
+      JSFull.JSPropertyString _ s -> [s]
+      JSFull.JSPropertyNumber _ s -> [s]
+  ]


### PR DESCRIPTION
## Summary
- add JavaScript source-position source tracking coverage and reparsing checks
- tighten JavaScript source span handling and add regression coverage for JSNoAnnot slices
- wire the new source-position specs into the existing test suite and scripts

## Testing
- devenv shell -- cabal test unit-tests --test-options='--match "source-position"'
